### PR TITLE
pc - update final quarter in dropdowns to be W23

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -10,7 +10,7 @@ import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
 import { useBackendMutation } from "main/utils/useBackend";
 
 const BasicCourseSearchForm = ({ fetchJSON }) => {
-  const quarters = quarterRange("20084", "20222");
+  const quarters = quarterRange("20084", "20231");
 
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -21,7 +21,7 @@ function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLab
 
     const navigate = useNavigate();
     const [quarter, setQuarter] = useState({
-        quarters: quarterRange("20081", "20213")
+        quarters: quarterRange("20081", "20231")
     }.quarters[0]);
 
     return (
@@ -80,7 +80,7 @@ function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLab
                     setQuarter={setQuarter} 
                     controlId={"PersonalScheduleForm-quarter"}
                     label={"Quarter"}
-                    quarters={quarterRange("20081", "20224") }/>
+                    quarters={quarterRange("20081", "20231") }/>
             </Form.Group>
 
 


### PR DESCRIPTION
Closes #5 

This changes the final quarter in a couple of quarter selectors to be W23.

Eventually, we should change this to be set by an environment variable instead of having to change the code every quarter.
