### PR TITLE
pc - update start and end quarters from systeminfo

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -14,9 +14,10 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   const { data: systemInfo } = useSystemInfo();
 
+  // Stryker disable OptionalChaining
   const startQtr = systemInfo?.startQtrYYYYQ || "20211";
   const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-
+  // Stryker enable OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);
 

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -10,7 +10,14 @@ import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
 import { useBackendMutation } from "main/utils/useBackend";
 
 const BasicCourseSearchForm = ({ fetchJSON }) => {
-  const quarters = quarterRange("20084", "20231");
+
+  const { data: systemInfo } = useSystemInfo();
+
+  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
+  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
+
+
+  const quarters = quarterRange(startQtr, endQtr);
 
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
@@ -26,6 +33,8 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const onSuccess = (listSubjects) => {
     setSubjects(listSubjects);
   };
+
+
 
   const getMutation = useBackendMutation(
     getObjectToAxiosParams,

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -4,6 +4,7 @@ import { Form, Button, Container, Row, Col } from "react-bootstrap";
 import { allTheLevels } from "fixtures/levelsFixtures";
 import { quarterRange } from "main/utils/quarterUtilities";
 
+import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
 import SingleLevelDropdown from "../Levels/SingleLevelDropdown";

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -9,6 +9,11 @@ import { quarterRange } from 'main/utils/quarterUtilities';
 
 function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLabel = "Create" }) {
 
+    const { data: systemInfo } = useSystemInfo();
+    const startQtr = systemInfo?.startQtrYYYYQ || "20211";
+    const endQtr = systemInfo?.endQtrYYYYQ || "20214";
+    const quarters = quarterRange(startQtr, endQtr);
+
     // Stryker disable all
     const {
         register,
@@ -21,7 +26,7 @@ function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLab
 
     const navigate = useNavigate();
     const [quarter, setQuarter] = useState({
-        quarters: quarterRange("20081", "20231")
+        quarters: quarters
     }.quarters[0]);
 
     return (
@@ -80,7 +85,7 @@ function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLab
                     setQuarter={setQuarter} 
                     controlId={"PersonalScheduleForm-quarter"}
                     label={"Quarter"}
-                    quarters={quarterRange("20081", "20231") }/>
+                    quarters={quarters}/>
             </Form.Group>
 
 

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -5,6 +5,8 @@ import { useNavigate } from 'react-router-dom'
 import SingleQuarterDropdown from '../Quarters/SingleQuarterDropdown';
 import { quarterRange } from 'main/utils/quarterUtilities';
 
+import { useSystemInfo } from "main/utils/systemInfo";
+
 
 
 function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLabel = "Create" }) {

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -12,8 +12,10 @@ import { useSystemInfo } from "main/utils/systemInfo";
 function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLabel = "Create" }) {
 
     const { data: systemInfo } = useSystemInfo();
+    // Stryker disable OptionalChaining
     const startQtr = systemInfo?.startQtrYYYYQ || "20211";
     const endQtr = systemInfo?.endQtrYYYYQ || "20214";
+    // Stryker enable OptionalChaining
     const quarters = quarterRange(startQtr, endQtr);
 
     // Stryker disable all

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -66,7 +66,7 @@ describe("BasicCourseSearchForm tests", () => {
 
   test("when I select a subject, the state for subject changes", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
-    
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -173,4 +173,26 @@ describe("BasicCourseSearchForm tests", () => {
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
   });
+
+
+  test("renders without crashing when fallback values are used", () => {
+
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": false,
+        "startQtrYYYYQ": null, // use fallback value
+        "endQtrYYYYQ": null  // use fallback value
+      });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BasicCourseSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
 });

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -175,7 +175,7 @@ describe("BasicCourseSearchForm tests", () => {
   });
 
 
-  test("renders without crashing when fallback values are used", () => {
+  test("renders without crashing when fallback values are used", async () => {
 
     axiosMock
       .onGet("/api/systemInfo")
@@ -193,6 +193,11 @@ describe("BasicCourseSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
+
+    // Make sure the first and last options 
+    expect(await screen.findByTestId(/BasicSearch.Quarter-option-0/)).toHaveValue("20211")
+    expect(await screen.findByTestId(/BasicSearch.Quarter-option-3/)).toHaveValue("20214")
+
   });
 
 });

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -4,6 +4,11 @@ import { BrowserRouter as Router } from "react-router-dom";
 import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
 import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
 
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
@@ -12,11 +17,30 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe("PersonalScheduleForm tests", () => {
+
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    beforeEach(() => {
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, {
+            "springH2ConsoleEnabled": false,
+            "showSwaggerUILink": false,
+            "startQtrYYYYQ": "20154",
+            "endQtrYYYYQ": "20162"
+        });
+    });
+
+    const queryClient = new QueryClient();
+
+
     test("renders correctly", async () => {
         render(
-            <Router>
-                <PersonalScheduleForm />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <PersonalScheduleForm />
+                </Router>
+            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Name/)).toBeInTheDocument();
@@ -27,9 +51,11 @@ describe("PersonalScheduleForm tests", () => {
 
     test("renders correctly when passing in a PersonalSchedule", async () => {
         render(
-            <Router>
-                <PersonalScheduleForm initialPersonalSchedule={personalSchedulesFixtures.onePersonalSchedule} />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <PersonalScheduleForm initialPersonalSchedule={personalSchedulesFixtures.onePersonalSchedule} />
+                </Router>
+            </QueryClientProvider>
         );
 
         expect(await screen.findByTestId(/PersonalScheduleForm-id/)).toBeInTheDocument();
@@ -39,9 +65,11 @@ describe("PersonalScheduleForm tests", () => {
 
     test("Correct Error messages on missing input", async () => {
         render(
-            <Router  >
-                <PersonalScheduleForm />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router  >
+                    <PersonalScheduleForm />
+                </Router>
+            </QueryClientProvider>
         );
         expect(await screen.findByTestId("PersonalScheduleForm-submit")).toBeInTheDocument();
         const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
@@ -56,9 +84,11 @@ describe("PersonalScheduleForm tests", () => {
         const mockSubmitAction = jest.fn();
 
         render(
-            <Router>
-                <PersonalScheduleForm submitAction={mockSubmitAction} />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <PersonalScheduleForm submitAction={mockSubmitAction} />
+                </Router>
+            </QueryClientProvider>
         );
 
         expect(await screen.findByTestId("PersonalScheduleForm-name")).toBeInTheDocument();
@@ -77,14 +107,16 @@ describe("PersonalScheduleForm tests", () => {
 
         expect(screen.queryByText(/Name is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Description is required./)).not.toBeInTheDocument();
-        expect(quarter).toHaveValue("20124");
+        expect(quarter).toHaveValue("20154");
     });
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {
         render(
-            <Router>
-                <PersonalScheduleForm />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <PersonalScheduleForm />
+                </Router>
+            </QueryClientProvider>
         );
         expect(await screen.findByTestId("PersonalScheduleForm-cancel")).toBeInTheDocument();
         const cancelButton = screen.getByTestId("PersonalScheduleForm-cancel");

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/SystemInfoController.java
@@ -6,7 +6,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +18,7 @@ public class SystemInfoController extends ApiController {
     @Autowired
     private SystemInfoService systemInfoService;
 
-    @ApiOperation(value = "Get global information about the application")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiOperation(value = "Get global public information about the application")
     @GetMapping("")
     public SystemInfo getSystemInfo() {
         return systemInfoService.getSystemInfo();

--- a/src/main/java/edu/ucsb/cs156/courses/models/CurrentUser.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/CurrentUser.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import lombok.Builder;
 import lombok.AccessLevel;
 
 

--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -4,10 +4,12 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import lombok.Builder;
 import lombok.AccessLevel;
 
-
+/**
+ * This class represents the public information about the application.
+ */
+ 
 @Data
 @Builder
 @AllArgsConstructor

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
@@ -27,15 +27,51 @@ public class SystemInfoControllerTests extends ControllerTestCase {
 
   @Test
   public void systemInfo__logged_out() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
+    // arrange
+
+    SystemInfo systemInfo = SystemInfo
+        .builder()
+        .showSwaggerUILink(true)
+        .springH2ConsoleEnabled(true)
+        .startQtrYYYYQ("20221")
+        .endQtrYYYYQ("20222")
+        .build();
+    when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
+    String expectedJson = mapper.writeValueAsString(systemInfo);
+
+    // act
+    MvcResult response = mockMvc.perform(get("/api/systemInfo"))
+        .andExpect(status().isOk()).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
+
+  
 
   @WithMockUser(roles = { "USER" })
   @Test
   public void systemInfo__user_logged_in() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
+    // arrange
+
+    SystemInfo systemInfo = SystemInfo
+        .builder()
+        .showSwaggerUILink(true)
+        .springH2ConsoleEnabled(true)
+        .startQtrYYYYQ("20221")
+        .endQtrYYYYQ("20222")
+        .build();
+    when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
+    String expectedJson = mapper.writeValueAsString(systemInfo);
+
+    // act
+    MvcResult response = mockMvc.perform(get("/api/systemInfo"))
+        .andExpect(status().isOk()).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })


### PR DESCRIPTION
# Overview

In this PR, we make it possible to adjust the start and end quarters in dropdowns such as the ones shown below, by just changing environment variables (no code change needed):

<img width="252" alt="image" src="https://user-images.githubusercontent.com/1119017/200711328-17ddc4b5-59d7-4063-a4f6-d9b8d91a453f.png">

<img width="161" alt="image" src="https://user-images.githubusercontent.com/1119017/200711370-d779dd73-19bb-4c15-bc3d-a2381babb8ab.png">

# Details

This PR changes the initialization of quarter selectors in the front end, so that they take their start and end quarter values from the /api/systeminfo endpoint rather than hard coded values.

And those /api/systeminfo endpoint values come from ENVIRONMENT VARIABLES:

* START_QTR
* END_QTR

Also, in this PR, we change the permissions for /api/systeminfo so that instead of requiring the user to have admin permission, the endpoint is available even when not logged in.

Closes #4 