### PR TITLE
pc - add backend for async job system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
             <version>2.0.1.Final</version>
         </dependency>
 
+          <!-- To help with testing async jobs; see http://www.awaitility.org/ https://stackoverflow.com/a/46227996 -->
+          <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+          </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -3,7 +3,11 @@ package edu.ucsb.cs156.courses;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
+import org.springframework.scheduling.annotation.EnableAsync;
+
 @SpringBootApplication
+@EnableAsync
 public class CoursesApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobService;
+
+@Slf4j
+@Api(description = "Jobs")
+@RequestMapping("/api/jobs")
+@RestController
+public class JobsController extends ApiController {
+    @Autowired
+    private JobsRepository jobsRepository;
+
+    @Autowired
+    private JobService jobService;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "List all jobs")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Job> allJobs() {
+        Iterable<Job> jobs = jobsRepository.findAll();
+        return jobs;
+    }
+
+    @ApiOperation(value = "Launch Test Job (click fail if you want to test exception handling)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/testjob")
+    public Job launchTestJob(
+        @ApiParam("fail") @RequestParam Boolean fail, 
+        @ApiParam("sleepMs") @RequestParam Integer sleepMs
+    ) {
+
+        return jobService.runAsJob(ctx -> {
+            ctx.log("Hello World! from test job!");
+            Thread.sleep(sleepMs);
+            if (fail) {
+                throw new Exception("Fail!");
+            }
+            ctx.log("Goodbye from test job!");
+          });
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -1,0 +1,38 @@
+package edu.ucsb.cs156.courses.entities;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "jobs")
+@EntityListeners(AuditingEntityListener.class)
+
+public class Job {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_id")
+    private User createdBy;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private String status;
+    private String log;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/JobsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/JobsRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.courses.repositories;
+
+import edu.ucsb.cs156.courses.entities.Job;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobsRepository extends CrudRepository<Job, Long> {
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContext.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContext.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class JobContext {
+  private JobsRepository jobsRepository;
+  private Job job;
+
+  public void log(String message) {
+    log.info("Job %s: %s".formatted(job.getId(), message));
+    String previousLog = job.getLog() == null ? "" : (job.getLog() + "\n");
+    job.setLog(previousLog + message);
+    jobsRepository.save(job);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContextConsumer.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContextConsumer.java
@@ -1,0 +1,6 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+@FunctionalInterface
+public interface JobContextConsumer {
+  void accept(JobContext c) throws Exception;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
@@ -1,0 +1,58 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.CurrentUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JobService {
+  @Autowired
+  private JobsRepository jobsRepository;
+
+  @Autowired
+  private CurrentUserService currentUserService;
+
+  @Lazy
+  @Autowired
+  private JobService self;
+
+
+  public Job runAsJob(JobContextConsumer jobFunction) {
+    Job job = Job.builder()
+      .createdBy(currentUserService.getUser())
+      .status("running")
+      .build();
+
+    jobsRepository.save(job);
+    self.runJobAsync(job, jobFunction, SecurityContextHolder.getContext());
+
+    return job;
+  }
+
+  
+
+  @Async
+  public void runJobAsync(Job job, JobContextConsumer jobFunction, SecurityContext securityContext) {
+    JobContext context = new JobContext(jobsRepository, job);
+
+    SecurityContextHolder.setContext(securityContext);
+
+    try {
+      jobFunction.accept(context);
+    } catch (Exception e) {
+      e.printStackTrace();
+      job.setStatus("error");
+      context.log(e.getMessage());
+      return;
+    }
+
+    job.setStatus("complete");
+    jobsRepository.save(job);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -1,0 +1,173 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import static org.awaitility.Awaitility.await;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebMvcTest(controllers = JobsController.class)
+@Import(JobService.class)
+@AutoConfigureDataJpa
+public class JobsControllerTests extends ControllerTestCase {
+
+  @MockBean
+  JobsRepository jobsRepository;
+
+  @MockBean
+  UserRepository userRepository;
+
+  @Autowired
+  JobService jobService;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void admin_can_get_all_jobs() throws Exception {
+
+    // arrange
+
+    Job job1 = Job.builder().log("this is job 1").build();
+    Job job2 = Job.builder().log("this is job 2").build();
+
+    ArrayList<Job> expectedJobs = new ArrayList<>();
+    expectedJobs.addAll(Arrays.asList(job1, job2));
+
+    when(jobsRepository.findAll()).thenReturn(expectedJobs);
+
+    // act
+    MvcResult response = mockMvc.perform(get("/api/jobs/all"))
+        .andExpect(status().isOk()).andReturn();
+
+    // // assert
+
+    verify(jobsRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedJobs);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void admin_can_launch_test_job() throws Exception {
+
+    // arrange
+
+    User user = currentUserService.getUser();
+
+    Job jobStarted = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("running")
+        .log("Hello World! from test job!")
+        .build();
+
+    Job jobCompleted = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("complete")
+        .log("Hello World! from test job!\nGoodbye from test job!")
+        .build();
+
+    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
+
+    // act
+    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=4000").with(csrf()))
+        .andExpect(status().isOk()).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+    assertEquals("running", jobReturned.getStatus());
+
+    await().atMost(1, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+    await().atMost(10, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobCompleted)));
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void admin_can_launch_test_job_that_fails() throws Exception {
+
+    // arrange
+
+    User user = currentUserService.getUser();
+
+    Job jobStarted = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("running")
+        .log("Hello World! from test job!")
+        .build();
+
+    Job jobFailed = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("error")
+        .log("Hello World! from test job!\nFail!")
+        .build();
+
+    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
+
+    // act
+    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+    assertEquals("running", jobReturned.getStatus());
+
+    await().atMost(1, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+
+    await().atMost(10, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobFailed)));
+  }
+}


### PR DESCRIPTION
This adds the ability to submit asynchronous jobs in the backend, including one demonstration test job.  Tests are included as well.

# User Stories

As a developer
* I can develop code for asynchronous jobs
* So that I can write code for tasks that take longer than a web request/response cycle to complete

As a developer
* I can test a simple asynchronous job that can both fail, and take an arbitrary amount of time to complete
* So that I can test the async job infrastructure independent of any specific application oriented job.

# Test Plan

Use Swagger.  

<img width="998" alt="image" src="https://user-images.githubusercontent.com/1119017/202262876-436a4ec1-b9f8-44fc-8f7d-e8848058d9fc.png">

First run the job that lists all job logs. 

![image](https://user-images.githubusercontent.com/1119017/202263223-5db50822-c54f-4a6d-b488-994c31b17966.png)

 The result may be an empty list (`[]`) if no one has run any async jobs yet on your test platform, but the normal response is something like that shown below:

```json
[
  {
    "id": 1,
    "createdAt": null,
    "updatedAt": null,
    "status": "complete",
    "log": "Hello World! from test job!\nGoodbye from test job!"
  },
  {
    "id": 2,
    "createdAt": null,
    "updatedAt": null,
    "status": "complete",
    "log": "Hello World! from test job!\nGoodbye from test job!"
  }
]
```


Then submit a job.  At first, use 6000 ms as the delay and fail = false so that you have time (within 6 seconds) to do another query on the job list and see the job show up as "running", e.g.:

```json
{
  "id": 4,
  "createdAt": null,
  "updatedAt": null,
  "status": "running",
  "log": "Hello World! from test job!"
}
```


Then do a subsequent query (after 6 seconds) to see the job completed.   

```json
{
    "id": 4,
    "createdAt": null,
    "updatedAt": null,
    "status": "complete",
    "log": "Hello World! from test job!\nGoodbye from test job!"
  }
```


This animation shows the expected result:

![image](https://user-images.githubusercontent.com/1119017/202264060-ea49f20f-7bc4-468e-b80a-a08f59457f36.png)

Then perform similar tests with longer and shorter values of sleepMs (including 0), and both true and false for the `fail` parameter.

When first submitted, a failed job will show up as normal (if there is sufficient delay; the delay is introduced before the exception is thrown).

```json
{
  "id": 6,
  "createdAt": null,
  "updatedAt": null,
  "status": "running",
  "log": "Hello World! from test job!"
}
```

But a subsequent GET query should show it has having had an error:

```json
{
    "id": 6,
    "createdAt": null,
    "updatedAt": null,
    "status": "error",
    "log": "Hello World! from test job!\nFail!"
  }
```

This animation demonstrates what you should see:

![image](https://user-images.githubusercontent.com/1119017/202264676-0d877fca-5473-4c0f-b15b-af7ee86d365c.png)
