### PR TITLE
Staff f22 pc jobs frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 frontend/.stryker-tmp
 frontend/reports
+frontend/strykerTmp
 
 # Don't check in a built storybook #
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
 import AdminPersonalSchedulesPage from "main/pages/AdminPersonalSchedulePage";
+import AdminJobsPage from "main/pages/AdminJobsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -34,6 +35,7 @@ function App() {
               <Route exact path="/admin/users" element={<AdminUsersPage />} />
               <Route exact path="/admin/loadsubjects" element={<AdminLoadSubjectsPage />} />
               <Route exact path="/admin/personalschedule" element={<AdminPersonalSchedulesPage />} />
+              <Route path="/admin/jobs" element={<AdminJobsPage />} />
             </>
           )
         }

--- a/frontend/src/fixtures/jobsFixtures.js
+++ b/frontend/src/fixtures/jobsFixtures.js
@@ -1,65 +1,65 @@
 const jobsFixtures = {
     oneCompleteJob:  {
         "id": 1,
-        "createdAt": "2022-11-13T19:49:58.097465",
-        "updatedAt": "2022-11-13T19:49:59.203879",
+        "createdAt": "2022-11-13T19:49:58.097465-08:00",
+        "updatedAt": "2022-11-13T19:49:59.203879-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
     oneRunningJob:  {
         "id": 6,
-        "createdAt": "2022-11-13T19:50:37.252253",
-        "updatedAt": "2022-11-13T19:50:37.258798",
+        "createdAt": "2022-11-13T19:50:37.252253-08:00",
+        "updatedAt": "2022-11-13T19:50:37.258798-08:00",
         "status": "running",
         "log": "Hello World! from test job!"
       },
     oneErroredJob:  {
         "id": 5,
-        "createdAt": "2022-11-13T19:50:34.097377",
-        "updatedAt": "2022-11-13T19:50:39.122652",
+        "createdAt": "2022-11-13T19:50:34.097377-08:00",
+        "updatedAt": "2022-11-13T19:50:39.122652-08:00",
         "status": "error",
         "log": "Hello World! from test job!\nFail!"
       },
     sixJobs: [
       {
         "id": 1,
-        "createdAt": "2022-11-13T19:49:58.097465",
-        "updatedAt": "2022-11-13T19:49:59.203879",
+        "createdAt": "2022-11-13T19:49:58.097465-08:00",
+        "updatedAt": "2022-11-13T19:49:59.203879-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 2,
-        "createdAt": "2022-11-13T19:50:00.349036",
-        "updatedAt": "2022-11-13T19:50:01.387745",
+        "createdAt": "2022-11-13T19:50:00.349036-08:00",
+        "updatedAt": "2022-11-13T19:50:01.387745-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 3,
-        "createdAt": "2022-11-13T19:50:16.810569",
-        "updatedAt": "2022-11-13T19:50:17.844532",
+        "createdAt": "2022-11-13T19:50:16.810569-08:00",
+        "updatedAt": "2022-11-13T19:50:17.844532-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 4,
-        "createdAt": "2022-11-13T19:50:17.770892",
-        "updatedAt": "2022-11-13T19:50:18.798021",
+        "createdAt": "2022-11-13T19:50:17.770892-08:00",
+        "updatedAt": "2022-11-13T19:50:18.798021-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 6,
-        "createdAt": "2022-11-13T19:50:37.252253",
-        "updatedAt": "2022-11-13T19:50:37.258798",
+        "createdAt": "2022-11-13T19:50:37.252253-08:00",
+        "updatedAt": "2022-11-13T19:50:37.258798-08:00",
         "status": "running",
         "log": "Hello World! from test job!"
       },
       {
         "id": 5,
-        "createdAt": "2022-11-13T19:50:34.097377",
-        "updatedAt": "2022-11-13T19:50:39.122652",
+        "createdAt": "2022-11-13T19:50:34.097377-08:00",
+        "updatedAt": "2022-11-13T19:50:39.122652-08:00",
         "status": "error",
         "log": "Hello World! from test job!\nFail!"
       }

--- a/frontend/src/fixtures/jobsFixtures.js
+++ b/frontend/src/fixtures/jobsFixtures.js
@@ -1,0 +1,77 @@
+const jobsFixtures = {
+    oneCompleteJob:  {
+        "id": 1,
+        "createdAt": "2022-11-13T19:49:58.097465",
+        "updatedAt": "2022-11-13T19:49:59.203879",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+    oneRunningJob:  {
+        "id": 6,
+        "createdAt": "2022-11-13T19:50:37.252253",
+        "updatedAt": "2022-11-13T19:50:37.258798",
+        "status": "running",
+        "log": "Hello World! from test job!"
+      },
+    oneErroredJob:  {
+        "id": 5,
+        "createdAt": "2022-11-13T19:50:34.097377",
+        "updatedAt": "2022-11-13T19:50:39.122652",
+        "status": "error",
+        "log": "Hello World! from test job!\nFail!"
+      },
+    sixJobs: [
+      {
+        "id": 1,
+        "createdAt": "2022-11-13T19:49:58.097465",
+        "updatedAt": "2022-11-13T19:49:59.203879",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 2,
+        "createdAt": "2022-11-13T19:50:00.349036",
+        "updatedAt": "2022-11-13T19:50:01.387745",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 3,
+        "createdAt": "2022-11-13T19:50:16.810569",
+        "updatedAt": "2022-11-13T19:50:17.844532",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 4,
+        "createdAt": "2022-11-13T19:50:17.770892",
+        "updatedAt": "2022-11-13T19:50:18.798021",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 6,
+        "createdAt": "2022-11-13T19:50:37.252253",
+        "updatedAt": "2022-11-13T19:50:37.258798",
+        "status": "running",
+        "log": "Hello World! from test job!"
+      },
+      {
+        "id": 5,
+        "createdAt": "2022-11-13T19:50:34.097377",
+        "updatedAt": "2022-11-13T19:50:39.122652",
+        "status": "error",
+        "log": "Hello World! from test job!\nFail!"
+      }
+    ],
+    testJobFailFalseSleepMs1000: {
+      "fail": false,
+      "sleepMs": 1000
+    },
+    testJobFailTrueSleepMs1000: {
+      "fail": false,
+      "sleepMs": 1000
+    },
+};
+
+export default jobsFixtures;

--- a/frontend/src/main/components/Jobs/JobComingSoon.js
+++ b/frontend/src/main/components/Jobs/JobComingSoon.js
@@ -1,0 +1,7 @@
+function JobComingSoon() {
+  return (
+    <p>Coming Soon! (The form for this job has not yet been created)</p>
+  );
+}
+
+export default JobComingSoon;

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -1,0 +1,39 @@
+import React from "react";
+import OurTable, {PlaintextColumn, DateColumn} from "main/components/OurTable";
+
+export default function JobsTable({ jobs }) {
+
+    const testid = "JobsTable";
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        DateColumn('Created', (cell)=>cell.row.original.createdAt),
+        DateColumn('Updated', (cell)=>cell.row.original.updatedAt),
+        {
+            Header:'Status',
+            accessor: 'status'
+        },
+        PlaintextColumn('Log', (cell)=>cell.row.original.log),
+    ];
+    
+    const sortees = React.useMemo(
+        () => [
+          {
+            id: "id",
+            desc: true
+          }
+        ],
+       // Stryker disable next-line all
+        []
+      );
+
+    return <OurTable
+        data={jobs}
+        columns={columns}
+        testid={testid}
+        initialState={{ sortBy: sortees }}
+    />;
+}; 

--- a/frontend/src/main/components/Jobs/TestJobForm.js
+++ b/frontend/src/main/components/Jobs/TestJobForm.js
@@ -1,0 +1,61 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+
+function TestJobForm({ submitAction }) {
+
+ const defaultValues = {
+    fail: false,
+    sleepMs: 1000
+};
+
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm(
+    { defaultValues: defaultValues }
+  );
+  // Stryker enable all
+
+  const testid = "TestJobForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="fail">Fail? (if checked, job will fail, to test error handling)</Form.Label>
+        <Form.Check 
+          data-testid={`${testid}-fail`}
+          type="checkbox"
+          id="fail"
+          {...register("fail")}
+        />
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="sleepMs">Sleep (milliseconds)</Form.Label>
+        <Form.Control
+          id="sleepMs"
+          data-testid={`${testid}-sleepMs`}
+          type="number"
+          step="100"
+          isInvalid={!!errors.sleepMs}
+          {...register("sleepMs", {
+            valueAsNumber: true,
+            required: "sleepMs is required (0 is ok)",
+            min: { value: 0, message: "sleepMs must be positive" },
+            max: { value: 60000, message: "sleepMs may not be > 60000 (1 minute)" },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.sleepMs?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid="TestJobForm-Submit-Button">Submit</Button>
+    </Form>
+  );
+}
+
+export default TestJobForm;

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -89,7 +89,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                     <NavDropdown.Item href="/admin/users" data-testid="appnavbar-admin-users">Users</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/personalschedule" data-testid="appnavbar-admin-personalschedule">Personal Schedules</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/loadsubjects" data-testid="appnavbar-admin-loadsubjects">Load Subjects</NavDropdown.Item>
-
+                    <NavDropdown.Item href="/admin/jobs" data-testid="appnavbar-admin-jobs">Manage Jobs</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { useTable, useSortBy } from 'react-table'
 import { Table, Button } from "react-bootstrap";
+import Plaintext from "main/components/Utils/Plaintext";
 
-export default function OurTable({ columns, data, testid = "testid" }) {
+export default function OurTable({ columns, data, testid = "testid", ...rest }) {
 
   const {
     getTableProps,
@@ -10,7 +11,13 @@ export default function OurTable({ columns, data, testid = "testid" }) {
     headerGroups,
     rows,
     prepareRow,
-  } = useTable({ columns, data }, useSortBy)
+  } = useTable({
+    columns,
+    data,
+    ...(rest.initialState && {
+      initialState: rest.initialState
+    })
+  }, useSortBy)
 
   return (
     <Table {...getTableProps()} striped bordered hover >
@@ -96,6 +103,36 @@ export function ButtonColumn(label, variant, callback, testid) {
         {label}
       </Button>
     )
+  }
+  return column;
+}
+
+export function PlaintextColumn(label, getText) {
+  const column = {
+    Header: label,
+    id: label,
+    Cell: ({ cell }) => (
+      <Plaintext text={getText(cell)} />
+    )
+  }
+  return column;
+}
+
+export function DateColumn(label, getDate) {
+  const options = {
+    year: 'numeric', month: 'numeric', day: 'numeric',
+    hour: 'numeric', minute: 'numeric', second: 'numeric',
+    hour12: false,
+    timeZone: 'America/Los_Angeles'
+  };
+  const column = {
+    Header: label,
+    id: label,
+    Cell: ({ cell }) => {
+      const date = new Date(getDate(cell));
+      const formattedDate = new Intl.DateTimeFormat('en-US', options).format(date);
+      return (<>{formattedDate}</>)
+    }
   }
   return column;
 }

--- a/frontend/src/main/components/Utils/Plaintext.js
+++ b/frontend/src/main/components/Utils/Plaintext.js
@@ -1,0 +1,22 @@
+// based in part on this SO answer: https://codereview.stackexchange.com/a/211511
+
+export default function Plaintext({text}) {
+  if (text==null) {
+    return (<pre data-testid="plaintext-empty"></pre>)
+  }
+  const textToRender = typeof text === "string" ? text : JSON.stringify(text, null, 2);
+  const [firstLine, ...rest] = textToRender.split('\n')
+  return (
+    <pre data-testid="plaintext">
+      <span>{ firstLine }</span>
+      {
+        rest.map((line) => (
+          <>
+            <br />
+            <span>{ line }</span>
+          </>
+        ))
+      }
+    </pre>
+  );
+}

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -1,0 +1,87 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import JobsTable from "main/components/Jobs/JobsTable";
+import { useBackend } from "main/utils/useBackend";
+import Accordion from 'react-bootstrap/Accordion';
+import TestJobForm from "main/components/Jobs/TestJobForm";
+import JobComingSoon from "main/components/Jobs/JobComingSoon";
+
+import { useBackendMutation } from "main/utils/useBackend";
+
+const AdminJobsPage = () => {
+
+    const refreshJobsIntervalMilliseconds = 5000;
+
+    // test job 
+
+    const objectToAxiosParamsTestJob = (data) => ({
+        url: `/api/jobs/launch/testjob?fail=${data.fail}&sleepMs=${data.sleepMs}`,
+        method: "POST"
+    });
+
+    // Stryker disable all
+    const testJobMutation = useBackendMutation(
+        objectToAxiosParamsTestJob,
+        {  },
+        ["/api/jobs/all"]
+    );
+    // Stryker enable all
+
+    const submitTestJob = async (data) => {
+        console.log("submitTestJob, data=", data);
+        testJobMutation.mutate(data);
+    }
+
+    // Stryker disable all 
+    const { data: jobs, error: _error, status: _status } =
+        useBackend(
+            ["/api/jobs/all"],
+            {
+                method: "GET",
+                url: "/api/jobs/all",
+            },
+            [],
+            { refetchInterval: refreshJobsIntervalMilliseconds }
+        );
+    // Stryker enable  all 
+
+    const jobLaunchers = [
+        {
+            name: "Test Job",
+            form:  <TestJobForm submitAction={submitTestJob} />
+        },
+        {
+            name: "Update Courses Database",
+            form: <JobComingSoon />
+        },
+        {
+            name: "Update Grade Info",
+            form: <JobComingSoon />
+        },
+    ]
+
+
+    return (
+        <BasicLayout>
+            <h2 className="p-3">Launch Jobs</h2>
+            <Accordion>
+                {
+                    jobLaunchers.map((jobLauncher, index) => (
+                        <Accordion.Item eventKey={index}>
+                            <Accordion.Header>{jobLauncher.name}</Accordion.Header>
+                            <Accordion.Body>
+                                {jobLauncher.form}
+                            </Accordion.Body>
+                        </Accordion.Item>
+                    ))
+                }
+            </Accordion>
+
+            <h2 className="p-3">Job Status</h2>
+
+            <JobsTable jobs={jobs} />
+        </BasicLayout>
+    );
+};
+
+export default AdminJobsPage;

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -9,7 +9,10 @@ const AdminUsersPage = () => {
         useBackend(
             // Stryker disable next-line all : don't test internal caching of React Query
             ["/api/admin/users"],
-            { method: "GET", url: "/api/admin/users" },
+            {
+                // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
+                 method: "GET", 
+                 url: "/api/admin/users" },
             []
         );
 

--- a/frontend/src/main/pages/Courses/PSCourseIndexPage.js
+++ b/frontend/src/main/pages/Courses/PSCourseIndexPage.js
@@ -13,7 +13,10 @@ export default function CoursesIndexPage() {
         useBackend(
             // Stryker disable next-line all : don't test internal caching of React Query
             ["/api/courses/user/all"],
-            { method: "GET", url: "/api/courses/user/all" },
+            { 
+               // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
+                method: "GET", 
+                url: "/api/courses/user/all" },
             []
         );
 

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -25,53 +25,47 @@ import { toast } from "react-toastify";
 //     []
 // );
 
-export function useBackend(queryKey, axiosParameters, initialData) {
+export function useBackend(queryKey, axiosParameters, initialData, rest) {
 
-    return useQuery(queryKey, async () => {
-        try {
-            const response = await axios(axiosParameters);
-            return response.data;
-        } catch (e) {
-            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-            toast(errorMessage);
-            console.error(errorMessage, e);
+    return useQuery({
+        queryKey: queryKey,
+        queryFn: async () => {
+            try {
+                const response = await axios(axiosParameters);
+                return response.data;
+            } catch (e) {
+                const errorMessage = `useBackend: Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}: ${e}`;
+                toast(errorMessage, { type: "error" });
+                console.error(errorMessage);
+            }
             throw e;
-        }
-    }, {
-        initialData
+        },
+        onError: (e) => {
+            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+            toast(errorMessage, { type: "error" });
+            console.error(errorMessage);
+        },
+        initialData: initialData,
+        ...rest
     });
 }
 
-// const wrappedParams = async (params) =>
-//   await ( await axios(params)).data;
-
-
-const reportAxiosError = (error) => {
-    console.error("Axios Error:", error);
-    toast(`Axios Error: ${error}`);
-    return null;
-};
-
 const wrappedParams = async (params) => {
-    try {
-        return await (await axios(params)).data;
-    } catch (rejectedValue) {
-        reportAxiosError(rejectedValue);
-        throw rejectedValue;
-    }
+    return await (await axios(params)).data;
 };
 
-export function useBackendMutation(objectToAxiosParams, useMutationParams, queryKey=null) {
+export function useBackendMutation(objectToAxiosParams, useMutationParams, queryKey = null) {
     const queryClient = useQueryClient();
 
     return useMutation((object) => wrappedParams(objectToAxiosParams(object)), {
-        onError: (data) => {
-            toast(`${data}`)
+        onError: (error) => {
+            const errorMessage = `useBackendMutation: Error communicating with backend via ${error.response.config.method} on ${error.response.config.url}`;
+            toast(errorMessage, { type: "error" });
         },
-        // Stryker disable all: Not sure how to set up the complex behavior needed to test this
+        // Stryker disable all : Not sure how to set up the complex behavior needed to test this
         onSettled: () => {
-            if (queryKey!==null)
-             queryClient.invalidateQueries(queryKey);
+            if (queryKey !== null)
+                queryClient.invalidateQueries(queryKey);
         },
         // Stryker enable all
         retry: false,

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -37,11 +37,11 @@ export function useBackend(queryKey, axiosParameters, initialData, rest) {
                 const errorMessage = `useBackend: Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}: ${e}`;
                 toast(errorMessage, { type: "error" });
                 console.error(errorMessage);
+                throw e;
             }
-            throw e;
         },
         onError: (e) => {
-            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}: ${e}`;
             toast(errorMessage, { type: "error" });
             console.error(errorMessage);
         },

--- a/frontend/src/stories/components/Jobs/JobsTable.stories.mdx
+++ b/frontend/src/stories/components/Jobs/JobsTable.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import JobsTable from "main/components/Jobs/JobsTable";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+
+<Meta
+  title="components/Jobs/JobsTable"
+  component={JobsTable}
+/>
+
+# Jobs
+
+Shows a table of log entries for background jobs.
+
+<Canvas>
+  <Story name="emptytable">
+    <JobsTable jobs={[]} />
+  </Story>
+  <Story name="six-jobs">
+    <JobsTable jobs={jobsFixtures.sixJobs} />
+  </Story>
+</Canvas>

--- a/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
+++ b/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
@@ -1,0 +1,20 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import TestJobForm from "main/components/Jobs/TestJobForm";
+
+<Meta
+  title="components/Jobs/TestJobForm"
+  component={TestJobForm}
+/>
+
+# TestJobForm
+
+A form for submitting the test job, with:
+* a checkbox for whether the job should fail or not
+* a numeric field for the amount of time the job should sleep (to simulate a long-running job)
+
+<Canvas>
+  <Story name="uncontrolled">
+    <TestJobForm submitAction={action("submit")} />
+  </Story>
+</Canvas>

--- a/frontend/src/stories/components/Utils/Plaintext.stories.mdx
+++ b/frontend/src/stories/components/Utils/Plaintext.stories.mdx
@@ -1,0 +1,22 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import Plaintext from "main/components/Utils/Plaintext";
+const multiline = "foo\nbar\n\nbaz"
+
+<Meta
+  title="components/Utils/Plaintext"
+  component={Plaintext}
+/>
+
+# Jobs
+
+Shows a table of log entries for background jobs.
+
+<Canvas>
+  <Story name="empty">
+    <Plaintext text={" "} />
+  </Story>
+  <Story name="three lines of text">
+    <Plaintext text={multiline} />
+  </Story>
+</Canvas>

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import JobsTable from "main/components/Jobs/JobsTable";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+describe("JobsTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={[]}  />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+
+  test("Has the expected column headers and content", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsFixtures.sixJobs}  />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ['id', 'Created', 'Updated', 'Status', 'Log'];
+    const expectedFields = ['id', 'Created', 'Updated','status', 'Log'];
+    const testId = "JobsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Created`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Updated`)).toHaveTextContent("11/13/2022, 19:49:59");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-status`)).toHaveTextContent("complete");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Log`)).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+
+    expect(screen.getByTestId(`JobsTable-header-id-sort-carets`)).toHaveTextContent("🔽");
+
+
+  });
+
+});
+

--- a/frontend/src/tests/components/Jobs/TestJobsForm.test.js
+++ b/frontend/src/tests/components/Jobs/TestJobsForm.test.js
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import TestJobsForm from "main/components/Jobs/TestJobForm";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("TestJobsForm tests", () => {
+  it("renders correctly with the right defaults", async () => {
+    render(
+      <Router >
+        <TestJobsForm jobs={jobsFixtures.sixJobs}/>
+      </Router>
+    );
+
+    expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+    expect(await screen.findByTestId("TestJobForm-sleepMs")).toBeInTheDocument();
+    expect(screen.getByText(/Submit/)).toBeInTheDocument();
+  });
+
+
+  it("has validation errors for required fields", async () => {
+    const submitAction = jest.fn();
+
+    render(
+      <Router  >
+        <TestJobsForm jobs={jobsFixtures.sixJobs}/>
+      </Router  >
+    );
+
+    expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+    const submitButton = screen.getByTestId("TestJobForm-Submit-Button");
+    const sleepMs = screen.getByTestId("TestJobForm-sleepMs");
+
+    expect(submitButton).toBeInTheDocument();
+    expect(sleepMs).toHaveValue(1000);
+
+    fireEvent.change(sleepMs, { target: { value: '70000' } })
+    fireEvent.click(submitButton);
+    expect(await screen.findByText(/sleepMs may not be/i)).toBeInTheDocument();
+    expect(submitAction).not.toBeCalled();
+  });
+});

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -1,22 +1,28 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import OurTable, {ButtonColumn} from "main/components/OurTable";
+import OurTable, { ButtonColumn, DateColumn, PlaintextColumn} from "main/components/OurTable";
 
 describe("OurTable tests", () => {
     const threeRows = [
         {
             col1: 'Hello',
             col2: 'World',
+            createdAt: '2021-04-01T04:00:00.000',
+            log: "foo\nbar\n  baz",
         },
         {
             col1: 'react-table',
             col2: 'rocks',
+            createdAt: '2022-01-04T14:00:00.000',
+            log: "foo\nbar",
+
         },
         {
             col1: 'whatever',
             col2: 'you want',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "bar\n  baz",
         }
     ];
-
     const clickMeCallback = jest.fn();
 
     const columns = [
@@ -29,6 +35,8 @@ describe("OurTable tests", () => {
             accessor: 'col2',
         },
         ButtonColumn("Click", "primary", clickMeCallback, "testId"),
+        DateColumn("Date", (cell) => cell.row.original.createdAt),
+        PlaintextColumn("Log", (cell) => cell.row.original.log),
     ];
 
     test("renders an empty table without crashing", () => {
@@ -37,7 +45,7 @@ describe("OurTable tests", () => {
         );
     });
 
-    test("renders a table with three rows without crashing", () => {
+    test("renders a table with two rows without crashing", () => {
         render(
             <OurTable columns={columns} data={threeRows} />
         );
@@ -58,7 +66,6 @@ describe("OurTable tests", () => {
         render(
             <OurTable columns={columns} data={threeRows} />
         );
-
         expect(await screen.findByTestId("testid-header-col1")).toBeInTheDocument();
     });
 

--- a/frontend/src/tests/components/Utils/Plaintext.test.js
+++ b/frontend/src/tests/components/Utils/Plaintext.test.js
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import Plaintext from "main/components/Utils/Plaintext"
+
+describe("Plaintext tests", () => {
+    test("renders the correct text", async () => {
+        // Arrange
+        const text = "foo\nbar\n  baz"
+
+        const [firstLine, ...rest] = text.split('\n')
+
+        // Act
+        render(
+            <Plaintext text={text}  />
+        );
+
+        // Assert
+        expect(await screen.findByText(firstLine)).toBeInTheDocument();
+        rest.forEach(line => {
+            expect(screen.getByText(line.trim())).toBeInTheDocument();
+        });
+    });
+
+    test("works on null parameter", async () => {
+        // Arrange
+      
+        // Act
+        render(
+            <Plaintext text={null}  />
+        );
+
+        // Assert
+        expect(await screen.findByTestId("plaintext-empty")).toBeInTheDocument();
+        const pre = screen.getByTestId("plaintext-empty");
+        expect(pre).toHaveTextContent("");
+    });
+
+
+    test("works on non-text types", async () => {
+        // Arrange
+      
+        // Act
+        render(
+            <Plaintext text={[30, "foo", true]}  />
+        );
+
+        // Assert
+        expect(await screen.findByTestId("plaintext")).toBeInTheDocument();
+        const pre = screen.getByTestId("plaintext");
+        expect(pre).toHaveTextContent('[ 30, "foo", true]');
+    });
+});

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -1,0 +1,84 @@
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import AdminJobsPage from "main/pages/AdminJobsPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+describe("AdminJobsPage tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/jobs/all").reply(200, jobsFixtures.sixJobs);
+
+    });
+
+    test("renders without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByText("Launch Jobs")).toBeInTheDocument();
+        expect(await screen.findByText("Job Status")).toBeInTheDocument();
+
+        ["Test Job", "Update Courses Database", "Update Grade Info"].map(
+            (jobName) => expect(screen.getByText(jobName)).toBeInTheDocument()
+        );
+
+
+        const testId = "JobsTable";
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Created`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Updated`)).toHaveTextContent("11/13/2022, 19:49:59");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-status`)).toHaveTextContent("complete");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Log`)).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+
+    });
+
+    test("user can submit a test job", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Test Job")).toBeInTheDocument();
+
+        const testJobButton = screen.getByText("Test Job");
+        expect(testJobButton).toBeInTheDocument();
+        testJobButton.click();
+
+        expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+
+        const sleepMsInput = screen.getByTestId("TestJobForm-sleepMs");
+        const submitButton = screen.getByTestId("TestJobForm-Submit-Button");
+
+        expect(sleepMsInput).toBeInTheDocument();
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.change(sleepMsInput, { target: { value: '0' } })
+        submitButton.click();
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/testjob?fail=false&sleepMs=0");
+});
+
+
+});

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -35,6 +35,14 @@ describe("AdminUsersPage tests", () => {
         );
 
         expect(await screen.findByText("Users")).toBeInTheDocument();
+        expect(await screen.findByTestId("UsersTable-cell-row-0-col-id")).toBeInTheDocument();
+
+
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-givenName`)).toHaveTextContent("Phill");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-familyName`)).toHaveTextContent("Conrad");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-email`)).toHaveTextContent("phtcon@ucsb.edu");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-admin`)).toHaveTextContent("true");
     });
 
     test("renders empty table when backend unavailable", async () => {

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
@@ -128,9 +128,9 @@ describe("PersonalSchedulesIndexPage tests", () => {
 
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
-        // const errorMessage = console.error.mock.calls[0][0];
-        // expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
-        // restoreConsole();
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
+        restoreConsole();
 
         expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
@@ -128,9 +128,9 @@ describe("PersonalSchedulesIndexPage tests", () => {
 
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
-        const errorMessage = console.error.mock.calls[0][0];
-        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
-        restoreConsole();
+        // const errorMessage = console.error.mock.calls[0][0];
+        // expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
+        // restoreConsole();
 
         expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -62,5 +62,14 @@ describe("utils/useBackend tests", () => {
         expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
         restoreConsole();
 
+        const messageA = "useBackend: Error communicating with backend via GET on /api/admin/users: Error: Request failed with status code 404"
+        const messageB = "Error communicating with backend via GET on /api/admin/users: Error: Request failed with status code 404"
+        
+
+        await waitFor(() => expect(mockToast).toHaveBeenCalled());
+        expect(mockToast).toHaveBeenCalledTimes(2);
+        expect(mockToast).toHaveBeenCalledWith(messageA,{type: "error"});
+        expect(mockToast).toHaveBeenCalledWith(messageB,{type: "error"});
+
     });
 });

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -14,7 +14,7 @@ jest.mock('react-toastify', () => {
     return {
         __esModule: true,
         ...originalModule,
-        toast: (x) => mockToast(x)
+        toast: (...params) => mockToast(...params),
     };
 });
 
@@ -55,9 +55,8 @@ describe("utils/useBackend tests", () => {
             ["initialData"]
         ), { wrapper });
 
-        await waitFor(() => result.current.isError);
-
-        expect(result.current.data).toEqual(["initialData"]);
+        
+        await waitFor(()=>expect(result.current.data).toEqual(["initialData"]) ); 
         await waitFor(() => expect(console.error).toHaveBeenCalled());
         const errorMessage = console.error.mock.calls[0][0];
         expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");

--- a/frontend/src/tests/utils/useBackendMutationFailure.test.js
+++ b/frontend/src/tests/utils/useBackendMutationFailure.test.js
@@ -15,7 +15,7 @@ jest.mock('react-toastify', () => {
     return {
         __esModule: true,
         ...originalModule,
-        toast: (x) => mockToast(x)
+        toast: (...params) => mockToast(...params)
     };
 });
 
@@ -82,15 +82,15 @@ describe("utils/useBackend tests", () => {
             });
 
             await waitFor(() => expect(mockToast).toHaveBeenCalled());
-            expect(mockToast).toHaveBeenCalledTimes(2);
-            expect(mockToast).toHaveBeenCalledWith("Axios Error: Error: Request failed with status code 404");
-            expect(mockToast).toHaveBeenCalledWith("Error: Request failed with status code 404");
+            expect(mockToast).toHaveBeenCalledTimes(1);
+            expect(mockToast).toHaveBeenCalledWith("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post",{type: "error"});
 
             expect(console.error).toHaveBeenCalledTimes(3);
-            const errorMessage0 = console.error.mock.calls[0][0];
-            expect(errorMessage0).toMatch(/Axios Error:/);
-            const errorMessage1 = console.error.mock.calls[2][0];
-            expect(errorMessage1).toBe("onError from mutation.mutate called!");
+
+            expect(console.error.mock.calls[1][0]).toEqual("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post");
+            expect(console.error.mock.calls[2][0]).toEqual("onError from mutation.mutate called!");
+            expect(console.error.mock.calls[2][1]).toEqual("Error: Request failed with status code 404");
+
             restoreConsole();
         });
     });

--- a/frontend/src/tests/utils/useBackendMutationFailure.test.js
+++ b/frontend/src/tests/utils/useBackendMutationFailure.test.js
@@ -81,16 +81,19 @@ describe("utils/useBackend tests", () => {
                 onError: (e) => console.error("onError from mutation.mutate called!", String(e).substring(0, 199))
             });
 
+            const messageA = "useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post"
+            const messageB = "onError from mutation.mutate called!"
+            const messageC = "Error: Request failed with status code 404"
+
             await waitFor(() => expect(mockToast).toHaveBeenCalled());
             expect(mockToast).toHaveBeenCalledTimes(1);
-            expect(mockToast).toHaveBeenCalledWith("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post",{type: "error"});
+            expect(mockToast).toHaveBeenCalledWith(messageA,{type: "error"});
 
-            expect(console.error).toHaveBeenCalledTimes(3);
-
-            expect(console.error.mock.calls[1][0]).toEqual("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post");
-            expect(console.error.mock.calls[2][0]).toEqual("onError from mutation.mutate called!");
-            expect(console.error.mock.calls[2][1]).toEqual("Error: Request failed with status code 404");
-
+            expect(console.error).toHaveBeenCalledTimes(2);
+            
+            expect(console.error.mock.calls[1][0]).toEqual(messageB);
+            expect(console.error.mock.calls[1][1]).toEqual(messageC)
+            
             restoreConsole();
         });
     });

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -1,12 +1,22 @@
 package edu.ucsb.cs156.courses;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import lombok.extern.slf4j.Slf4j;
+
 @SpringBootApplication
-@EnableJpaAuditing // enables automatic population of @CreatedDate and @LastModifiedDate
+@EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
+// enables automatic population of @CreatedDate and @LastModifiedDate
 @EnableAsync // for @Async annotation for JobsService
 public class CoursesApplication {
 
@@ -14,4 +24,11 @@ public class CoursesApplication {
     SpringApplication.run(CoursesApplication.class, args);
   }
 
+  @Bean
+    public DateTimeProvider utcDateTimeProvider() {
+        return () -> {
+          ZonedDateTime now = ZonedDateTime.now();
+          return Optional.of(now);
+        };
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -2,12 +2,12 @@ package edu.ucsb.cs156.courses;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
-@EnableAsync
+@EnableJpaAuditing // enables automatic population of @CreatedDate and @LastModifiedDate
+@EnableAsync // for @Async annotation for JobsService
 public class CoursesApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 @Data
 @AllArgsConstructor
@@ -29,9 +29,9 @@ public class Job {
     private User createdBy;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private ZonedDateTime updatedAt;
 
     private String status;
     private String log;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/ApiControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -24,6 +25,7 @@ import java.util.Arrays;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class ApiControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CSRFControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CSRFControllerTests.java
@@ -5,6 +5,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("development")
 @WebMvcTest(controllers = CSRFController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class CSRFControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.courses.entities.PersonalSchedule;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = PSCourseController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class PSCourseControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -8,6 +8,7 @@ import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = PersonalSchedulesController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSectionsControllerTests.java
@@ -16,6 +16,7 @@ import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -57,6 +58,7 @@ import java.io.*;
 
 @WebMvcTest(controllers = {PersonalSectionsController.class})
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class PersonalSectionsControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.SystemInfoService;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = SystemInfoController.class)
+@AutoConfigureDataJpa
 public class SystemInfoControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -26,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(value = UCSBCurriculumController.class)
 @Import(SecurityConfig.class)
+@AutoConfigureDataJpa
 public class UCSBCurriculumControllerTests {
     private final Logger logger = LoggerFactory.getLogger(UCSBCurriculumControllerTests.class);
     private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -26,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(value = UCSBSectionsController.class)
 @Import(SecurityConfig.class)
+@AutoConfigureDataJpa
 public class UCSBSectionsControllerTests {
     private final Logger logger = LoggerFactory.getLogger(UCSBSectionsControllerTests.class);
     private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSubjectsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSubjectsControllerTests.java
@@ -9,6 +9,7 @@ import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.doNothing;
 
 @WebMvcTest(controllers = UCSBSubjectsController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UserInfoControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = UserInfoController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class UserInfoControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -24,6 +25,7 @@ import java.util.Arrays;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class UsersControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -32,6 +33,7 @@ import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.SectionFixtures;
 
 @RestClientTest(UCSBCurriculumService.class)
+@AutoConfigureDataJpa
 public class UCSBCurriculumServiceTests {
 
     @Value("${app.ucsb.api.consumer_key}")

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBSubjectsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBSubjectsServiceTests.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.test.web.client.MockRestServiceServer;
 
@@ -28,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 @RestClientTest(UCSBSubjectsService.class)
+@AutoConfigureDataJpa
 class UCSBSubjectsServiceTests {
 
   @Autowired


### PR DESCRIPTION
# Overview

In this PR we add the frontend code for the background jobs system (i.e. asynchronous long running jobs).

Async Jobs allow our application to do things that take longer than a single web request/response transaction (i.e. things that take longer than a second or two).  Most web servers will timeout if a request/response takes longer than some threshold, ranging somewhere between 1 second and 5 seconds.   The timeouts typically don't happen when testing on localhost, but do happen when deployed on real web servers.  

Another PR introduced the async job backend.  This PR fixes a couple of small backend problems, as well as adding the frontend components.

# User Story

As an admin and/or developer
* I can launch async jobs
* So that we can add more new features to the app that take longer than a second to execute, such as loading data

# How to Test

1. Login as an admin
2. Find the Manage Jobs item on the Admin menu
3. Click to open the Test Job panel
4. Submit a job with fail=false, and sleepMs=4000
5. You should see that job appear in the job list
6. After 4 seconds it's status should change to complete and log output should be updated.

Try this again with fail=true, and various values of sleepMs including 0

# A Guide to the Code

There's a lot going on in this PR; sorry for the size of it.  Here's an overview of the changes to the code:

Frontend:
* App.js: We added a route for the frontend Admin Jobs page
* jobsFixtures.js: fixtures for the backend route that handles jobs
* JobComingSoon.js: a component that's a placeholder for future jobs in the frontend
* JobsTable.js: a component for displaying information from jobs
* TestJobForm.js: a form for filling in the information that we have to submit to the test job (fail true/false, and the number of milliseconds to sleep)
* AppNavbar.js: we added a link to the AdminJobsPage
* OurTable.js: we added two new column types: 
  - a date column type that automatically handles time zone information and formatting and renders a date/time in a readable format in the local time zone
  - a column type for preformatted raw ASCII text (for the logs), uses `Plaintext.js` below
* Plaintext.js: a component for raw preformatted ASCII text (for the logs)
* useBackend.js: some adjustments to error handling to make it more robust and testable
* stories: stories for new components listed above
* tests: tests for changes listed above

Backend:
* CoursesApplication.java: Added an annotation on the main class, `@EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")` to enable th createdAt and updatedAt fields on entities to be automatically populated, and a method to provide the date with a timezone
* Job.java: changed LocalDateTime to ZonedDateTime so that job dates display in the correct time zone (they are supposed to be stored in UTC but displayed in localtime)
* Many controller tests and service tests; just needed `@AutoConfigureDataJpa` added so that the bean to provide date/time for JPA operations is provided in the test environment



