### PR TITLE
pc - update ci-cd to make sure jacoco and pitest coverage threshold i…

### DIFF
--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test jacoco:report verify
-   - name: Upload Jacoco reports to Artifacts
+    - name: Upload Jacoco reports to Artifacts
       if: always() # always upload artifacts, even on failure
       uses: actions/upload-artifact@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
 
-            <!-- Test case coverage report -->
-            <plugin>
+             <!-- Test case coverage report -->
+             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
@@ -175,7 +175,6 @@
                                     </limits>
                                 </rule>
                             </rules>
-
                         </configuration>
                     </execution>
                 </executions>
@@ -191,7 +190,7 @@
                 </configuration>
 
             </plugin>
-
+            
             <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
@@ -339,4 +338,4 @@
             </build>
         </profile>
     </profiles>
-</project>
+</project> 


### PR DESCRIPTION
In this PR, we update:

* the plugin configuration in pom.xml for jacoco, to specify thresholds
* the commands in the jacoco and pitest files that enforce coverage
* uploading of artifacts for jacoco and pitest