### PR TITLE
Staff f22 start update course job

### DIFF
--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -6,8 +6,12 @@ name: "10-backend-unit: Java Unit tests"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [src/**, pom.xml, lombok.config]
   push:
     branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config]
+
+    
 
 jobs:
   build:

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -6,8 +6,10 @@ name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [src/**, pom.xml, lombok.config]
   push:
     branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config]
 
 jobs:
   build:

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -6,8 +6,10 @@ name: "14-backend-pitest: Java Mutation Testing (Pitest)"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [src/**, pom.xml, lombok.config]
   push:
     branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config]
 
 jobs:
   build:

--- a/.github/workflows/30-frontend-tests.yml
+++ b/.github/workflows/30-frontend-tests.yml
@@ -3,9 +3,10 @@ name: "30-frontend-tests: JavaScript, Jest Unit tests"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   build:

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -3,9 +3,10 @@ name: "32-frontend-coverage: Frontend Coverage (JavaScript/Jest)"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   build:
@@ -27,9 +28,10 @@ jobs:
         working-directory: ./frontend
       - run: npm run coverage
         working-directory: ./frontend
-      - name: Upload to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
-        working-directory: ./frontend
+      - name: Upload reports to Artifacts
+        if: always() # always upload artifacts, even on failure
+        uses: actions/upload-artifact@v2
+        with:
+          name: jest-coverage-report
+          path: frontend/coverage/lcov-report/*
      

--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -3,9 +3,10 @@ name: "34-frontend-mutation-testing: Stryker JS Mutation Testing (JavaScript/Jes
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   build:
@@ -27,3 +28,10 @@ jobs:
         working-directory: ./frontend
       - run: npx stryker run
         working-directory: ./frontend
+      - name: Upload reports to Artifacts
+        if: always() # always upload artifacts, even on failure
+        uses: actions/upload-artifact@v2
+        with:
+          name: stryker-report
+          path: frontend/reports/mutation/html
+

--- a/.github/workflows/36-frontend-eslint.yml
+++ b/.github/workflows/36-frontend-eslint.yml
@@ -3,9 +3,10 @@ name: "36-frontend-eslint: JavaScript style checking"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   lint:

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -11,7 +11,8 @@ module.exports = {
   "addons": [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app"
+    "@storybook/preset-create-react-app",
+    'storybook-addon-mock',
   ],
   webpackFinal: async (config) => {
     config.plugins.push(new WebpackPluginFailBuildOnWarning());

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,7 +48,8 @@
         "eslint-plugin-react": "^7.30.0",
         "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
         "jest-mock-console": "^1.1.0",
-        "react-test-renderer": "^17.0.2"
+        "react-test-renderer": "^17.0.2",
+        "storybook-addon-mock": "^3.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1847,11 +1848,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -25098,6 +25099,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/mock-xmlhttprequest": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/mock-xmlhttprequest/-/mock-xmlhttprequest-7.0.4.tgz",
+      "integrity": "sha512-hA0fIHy/74p5DE0rdmrpU0sV1U+gnWTcgShWequGRLy0L1eT+zY0ozFukawpLaxMwIA+orRcqFRElYwT+5p81A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -26483,12 +26493,12 @@
       }
     },
     "node_modules/polished": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
-      "integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz",
+      "integrity": "sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.16.7"
+        "@babel/runtime": "^7.17.8"
       },
       "engines": {
         "node": ">=10"
@@ -29443,9 +29453,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -31439,6 +31449,39 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.1.tgz",
       "integrity": "sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==",
+      "dev": true
+    },
+    "node_modules/storybook-addon-mock": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-mock/-/storybook-addon-mock-3.2.0.tgz",
+      "integrity": "sha512-LaggsF/6Lt0AyHiotIEVQpwKfIiZ3KsNqtdXKVnIdOetjaD7GaOQeX0jIZiZUFX/i6QLmMuNoXFngqqkdVtfSg==",
+      "dev": true,
+      "dependencies": {
+        "mock-xmlhttprequest": "^7.0.3",
+        "path-to-regexp": "^6.2.0",
+        "polished": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@storybook/addons": "^6.4.0",
+        "@storybook/api": "^6.4.0",
+        "@storybook/components": "^6.4.0",
+        "@storybook/theming": "^6.4.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook-addon-mock/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/stream-browserify": {
@@ -36087,11 +36130,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/runtime-corejs3": {
@@ -53893,6 +53936,12 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "mock-xmlhttprequest": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/mock-xmlhttprequest/-/mock-xmlhttprequest-7.0.4.tgz",
+      "integrity": "sha512-hA0fIHy/74p5DE0rdmrpU0sV1U+gnWTcgShWequGRLy0L1eT+zY0ozFukawpLaxMwIA+orRcqFRElYwT+5p81A==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -54990,12 +55039,12 @@
       }
     },
     "polished": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
-      "integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz",
+      "integrity": "sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.16.7"
+        "@babel/runtime": "^7.17.8"
       }
     },
     "portfinder": {
@@ -57023,9 +57072,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -58607,6 +58656,25 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.1.tgz",
       "integrity": "sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==",
       "dev": true
+    },
+    "storybook-addon-mock": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-mock/-/storybook-addon-mock-3.2.0.tgz",
+      "integrity": "sha512-LaggsF/6Lt0AyHiotIEVQpwKfIiZ3KsNqtdXKVnIdOetjaD7GaOQeX0jIZiZUFX/i6QLmMuNoXFngqqkdVtfSg==",
+      "dev": true,
+      "requires": {
+        "mock-xmlhttprequest": "^7.0.3",
+        "path-to-regexp": "^6.2.0",
+        "polished": "^4.2.2"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+          "dev": true
+        }
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,8 @@
     "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
     "jest-mock-console": "^1.1.0",
-    "react-test-renderer": "^17.0.2"
+    "react-test-renderer": "^17.0.2",
+    "storybook-addon-mock": "^3.2.0"
   },
   "scripts": {
     "start": "env-cmd -f ../.env -e development react-scripts start",

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -36,7 +36,9 @@ const UpdateCoursesJobForm = ({ callback }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    callback({quarter, subject});
+    console.log("UpdateCoursesJobForm: quarter", quarter);
+    console.log("UpdateCoursesJobForm: subject", subject);
+    callback({ quarter, subject});
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -1,16 +1,14 @@
 import { useState } from "react";
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
 
-import { allTheLevels } from "fixtures/levelsFixtures";
 import { quarterRange } from "main/utils/quarterUtilities";
 
 import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
-import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
 import { useBackend  } from "main/utils/useBackend";
 
-const BasicCourseSearchForm = ({ fetchJSON }) => {
+const UpdateCoursesJobForm = ({ callback }) => {
 
   const { data: systemInfo } = useSystemInfo();
 
@@ -24,7 +22,6 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
-  const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
 
   const { data: subjects, error: _error, status: _status } =
   useBackend(
@@ -36,11 +33,10 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || {});
-  const [level, setLevel] = useState(localLevel || "U");
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { quarter, subject, level });
+    callback({quarter, subject});
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
@@ -64,19 +60,11 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
               controlId={"BasicSearch.Subject"}
             />
           </Col>
-          <Col md="auto">
-            <SingleLevelDropdown
-              levels={allTheLevels}
-              level={level}
-              setLevel={setLevel}
-              controlId={"BasicSearch.Level"}
-            />
-          </Col>
         </Row>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
           <Col md="auto">
             <Button variant="primary" type="submit">
-              Submit
+              Update Courses
             </Button>
           </Col>
         </Row>
@@ -85,4 +73,4 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   );
 };
 
-export default BasicCourseSearchForm;
+export default UpdateCoursesJobForm;

--- a/frontend/src/main/components/Subjects/SingleSubjectDropdown.js
+++ b/frontend/src/main/components/Subjects/SingleSubjectDropdown.js
@@ -36,8 +36,9 @@ const SingleSubjectDropdown = ({
         value={subjectState}
         onChange={handleSubjectOnChange}
       >
-        {subjects.map(function (object, i) {
-          const key = `${controlId}-option-${i}`;
+        {subjects.map(function (object) {
+          const subjectCode = object.subjectCode.replace(/ /g, "-");
+          const key = `${controlId}-option-${subjectCode}`;
           return (
             <option key={key} data-testid={key} value={object.subjectCode}>
               {object.subjectCode} - {object.subjectTranslation}

--- a/frontend/src/main/components/Utils/Plaintext.js
+++ b/frontend/src/main/components/Utils/Plaintext.js
@@ -1,5 +1,7 @@
 // based in part on this SO answer: https://codereview.stackexchange.com/a/211511
 
+import PlaintextLine from "./PlaintextLine";
+
 export default function Plaintext({text}) {
   if (text==null) {
     return (<pre data-testid="plaintext-empty"></pre>)
@@ -8,14 +10,9 @@ export default function Plaintext({text}) {
   const [firstLine, ...rest] = textToRender.split('\n')
   return (
     <pre data-testid="plaintext">
-      <span>{ firstLine }</span>
+      <span key={"span-0"}>{ firstLine }</span>
       {
-        rest.map((line) => (
-          <>
-            <br />
-            <span>{ line }</span>
-          </>
-        ))
+        rest.map((line,index) => <PlaintextLine key={index+1} text={line} />)
       }
     </pre>
   );

--- a/frontend/src/main/components/Utils/Plaintext.js
+++ b/frontend/src/main/components/Utils/Plaintext.js
@@ -2,17 +2,18 @@
 
 import PlaintextLine from "./PlaintextLine";
 
-export default function Plaintext({text}) {
-  if (text==null) {
+export default function Plaintext({ text }) {
+  if (text == null) {
     return (<pre data-testid="plaintext-empty"></pre>)
   }
   const textToRender = typeof text === "string" ? text : JSON.stringify(text, null, 2);
   const [firstLine, ...rest] = textToRender.split('\n')
   return (
     <pre data-testid="plaintext">
-      <span key={"span-0"}>{ firstLine }</span>
+      <span key={"0"}>{firstLine}</span>
       {
-        rest.map((line,index) => <PlaintextLine key={index+1} text={line} />)
+        // Stryker disable next-line ArithmeticOperator : key value is internal to React and not exposed to tests
+        rest.map((line, index) => <PlaintextLine key={index + 1} text={line} />)
       }
     </pre>
   );

--- a/frontend/src/main/components/Utils/PlaintextLine.js
+++ b/frontend/src/main/components/Utils/PlaintextLine.js
@@ -1,0 +1,9 @@
+// based in part on this SO answer: https://codereview.stackexchange.com/a/211511
+
+export default function PlaintextLine({ text }) {
+    return (
+        <>
+            <br /><span >{text}</span>
+        </>
+    )
+}

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -7,6 +7,7 @@ import TestJobForm from "main/components/Jobs/TestJobForm";
 import JobComingSoon from "main/components/Jobs/JobComingSoon";
 
 import { useBackendMutation } from "main/utils/useBackend";
+import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
 
 const AdminJobsPage = () => {
 
@@ -22,7 +23,7 @@ const AdminJobsPage = () => {
     // Stryker disable all
     const testJobMutation = useBackendMutation(
         objectToAxiosParamsTestJob,
-        {  },
+        {},
         ["/api/jobs/all"]
     );
     // Stryker enable all
@@ -30,6 +31,26 @@ const AdminJobsPage = () => {
     const submitTestJob = async (data) => {
         console.log("submitTestJob, data=", data);
         testJobMutation.mutate(data);
+    }
+
+    // ***** update courses job *******
+
+    const objectToAxiosParamsUpdateCoursesJob = (data) => ({
+        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.subject}`,
+        method: "POST"
+    });
+
+    // Stryker disable all
+    const updateCoursesJobMutation = useBackendMutation(
+        objectToAxiosParamsUpdateCoursesJob,
+        {},
+        ["/api/jobs/all"]
+    );
+    // Stryker enable all
+
+    const submitUpdateCoursesJob = async (data) => {
+        console.log("submitUpdateCoursesJob, data=", data);
+        updateCoursesJobMutation.mutate(data);
     }
 
     // Stryker disable all 
@@ -48,11 +69,11 @@ const AdminJobsPage = () => {
     const jobLaunchers = [
         {
             name: "Test Job",
-            form:  <TestJobForm submitAction={submitTestJob} />
+            form: <TestJobForm submitAction={submitTestJob} />
         },
         {
             name: "Update Courses Database",
-            form: <JobComingSoon />
+            form: <UpdateCoursesJobForm callback={submitUpdateCoursesJob}  />
         },
         {
             name: "Update Grade Info",
@@ -67,7 +88,7 @@ const AdminJobsPage = () => {
             <Accordion>
                 {
                     jobLaunchers.map((jobLauncher, index) => (
-                        <Accordion.Item eventKey={index}>
+                        <Accordion.Item eventKey={index} key={index}>
                             <Accordion.Header>{jobLauncher.name}</Accordion.Header>
                             <Accordion.Body>
                                 {jobLauncher.form}

--- a/frontend/src/stories/components/BasicCourseSearch/BasicCourseSearchForm.stories.js
+++ b/frontend/src/stories/components/BasicCourseSearch/BasicCourseSearchForm.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
-import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
+import { allTheSubjects } from "fixtures/subjectFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
@@ -13,7 +13,7 @@ export default {
         url: '/api/UCSBSubjects/all',
         method: 'GET',
         status: 200,
-        response: ucsbSubjectsFixtures.threeSubjects
+        response: allTheSubjects
       },
       {
         url: '/api/systemInfo',

--- a/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
+++ b/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 import TestJobForm from "main/components/Jobs/TestJobForm";
 

--- a/frontend/src/stories/components/Jobs/UpdateCoursesJobForm.stories.js
+++ b/frontend/src/stories/components/Jobs/UpdateCoursesJobForm.stories.js
@@ -1,12 +1,12 @@
 import React from "react";
 
-import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
+import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
 import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
-  title: "components/BasicCourseSearch/BasicCourseSearchForm",
-  component: BasicCourseSearchForm,
+  title: "components/Jobs/UpdateCoursesJobForm",
+  component: UpdateCoursesJobForm,
   parameters: {
     mockData: [
       {
@@ -19,21 +19,20 @@ export default {
         url: '/api/systemInfo',
         method: 'GET',
         status: 200,
-        response: systemInfoFixtures.showingBothStartAndEndQtr
+        response: systemInfoFixtures.showingBoth
       },
     ],
   },
 };
 
 const Template = (args) => {
-  return <BasicCourseSearchForm {...args} />;
+  return <UpdateCoursesJobForm {...args} />;
 };
 
 export const Default = Template.bind({});
 
 Default.args = {
-  submitText: "Create",
-  fetchJSON: (_event, data) => {
+  callback: (data) => {
     console.log("Submit was clicked, data=", data);
   }
 };

--- a/frontend/src/stories/pages/AdminJobsPage.stories.js
+++ b/frontend/src/stories/pages/AdminJobsPage.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import AdminJobsPage from "main/pages/AdminJobsPage";
+import jobsFixtures from 'fixtures/jobsFixtures';
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
+import { ucsbSubjectsFixtures } from 'fixtures/ucsbSubjectsFixtures';
+import { apiCurrentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'pages/AdminJobsPage',
+    component: AdminJobsPage,
+    parameters: {
+        mockData: [
+            {
+                url: '/api/UCSBSubjects/all',
+                method: 'GET',
+                status: 200,
+                response: ucsbSubjectsFixtures.threeSubjects
+            },
+            {
+                url: '/api/jobs/all',
+                method: 'GET',
+                status: 200,
+                response: jobsFixtures.sixJobs
+            },
+            {
+                url: '/api/systemInfo',
+                method: 'GET',
+                status: 200,
+                response: systemInfoFixtures.showingBoth
+            },
+            {
+                url: '/api/currentUser',
+                method: 'GET',
+                status: 200,
+                response: apiCurrentUserFixtures.adminUser
+            },
+        ],
+    },
+};
+
+const Template = () => <AdminJobsPage />;
+
+export const Default = Template.bind({});
+

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -19,27 +19,32 @@ jest.mock("react-toastify", () => ({
 
 describe("BasicCourseSearchForm tests", () => {
 
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const queryClient = new QueryClient();
+  const addToast = jest.fn();
+
   beforeEach(() => {
+    jest.clearAllMocks();
     jest.spyOn(console, 'error')
     console.error.mockImplementation(() => null);
-  });
 
-  const axiosMock = new AxiosMockAdapter(axios);
-  beforeEach(() => {
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
     axiosMock
       .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  });
-  const queryClient = new QueryClient();
-  const addToast = jest.fn();
-  beforeEach(() => {
+      .reply(200, {
+        ...systemInfoFixtures.showingNeither,
+        "startQtrYYYYQ": "20201",
+        "endQtrYYYYQ": "20214"
+      });
+
     toast.mockReturnValue({
       addToast: addToast,
     });
   });
+
 
   test("renders without crashing", () => {
     render(
@@ -75,11 +80,12 @@ describe("BasicCourseSearchForm tests", () => {
       </QueryClientProvider>
     );
 
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
-    });
+    const expectedKey = "BasicSearch.Subject-option-MATH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
+
     const selectSubject = screen.getByLabelText("Subject Area");
     userEvent.selectOptions(selectSubject, "MATH");
+
     expect(selectSubject.value).toBe("MATH");
   });
 
@@ -120,13 +126,13 @@ describe("BasicCourseSearchForm tests", () => {
       level: "G",
     };
 
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
-    });
+    const expectedKey = "BasicSearch.Subject-option-ANTH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
 
     const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20211");
     const selectSubject = screen.getByLabelText("Subject Area");
+    expect(selectSubject).toBeInTheDocument();
     userEvent.selectOptions(selectSubject, "ANTH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
@@ -143,6 +149,7 @@ describe("BasicCourseSearchForm tests", () => {
 
   test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+
     const sampleReturnValue = {
       sampleKey: "sampleValue",
       total: 0,
@@ -160,9 +167,8 @@ describe("BasicCourseSearchForm tests", () => {
       </QueryClientProvider>
     );
 
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
-    });
+    const expectedKey = "BasicSearch.Subject-option-MATH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
 
     const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20204");

--- a/frontend/src/tests/components/Jobs/TestJobsForm.test.js
+++ b/frontend/src/tests/components/Jobs/TestJobsForm.test.js
@@ -14,7 +14,7 @@ describe("TestJobsForm tests", () => {
   it("renders correctly with the right defaults", async () => {
     render(
       <Router >
-        <TestJobsForm jobs={jobsFixtures.sixJobs}/>
+        <TestJobsForm />
       </Router>
     );
 

--- a/frontend/src/tests/components/Jobs/UpdateCoursesJobForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCoursesJobForm.test.js
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+const queryClient = new QueryClient();
+
+describe("UpdateCoursesJobForm tests", () => {
+
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  it("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router >
+          <UpdateCoursesJobForm />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByText(/Update Courses/)).toBeInTheDocument();
+  });
+
+  test("renders without crashing when fallback values are used", async () => {
+
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": false,
+        "startQtrYYYYQ": null, // use fallback value
+        "endQtrYYYYQ": null  // use fallback value
+      });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router >
+          <UpdateCoursesJobForm />
+        </Router >
+      </QueryClientProvider>
+    );
+
+    // Make sure the first and last options 
+    expect(await screen.findByTestId(/BasicSearch.Quarter-option-0/)).toHaveValue("20211")
+    expect(await screen.findByTestId(/BasicSearch.Quarter-option-3/)).toHaveValue("20214")
+
+  });
+
+
+});

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -47,7 +47,39 @@ describe("SingleSubjectDropdown tests", () => {
     );
   });
 
-  test("renders without crashing on three subjects", () => {
+  test("renders without crashing on three subjects", async () => {
+     const { getAllByTestId} = render(
+      <SingleSubjectDropdown
+        subjects={[ 
+          threeSubjects[2],
+          threeSubjects[0],
+          threeSubjects[1]
+        ]}
+        subject={subject}
+        setSubject={setSubject}
+        controlId="ssd1"
+      />
+    );
+
+    const ART_CS = "ssd1-option-ART--CS";
+    const ANTH = "ssd1-option-ANTH";
+    const ARTHI = "ssd1-option-ARTHI";
+
+    // Check that blanks are replaced with hyphens
+    await waitFor(() => expect(screen.getByTestId(ART_CS).toBeInTheDocument));
+
+    // Check that the options are sorted
+    // See: https://www.atkinsondev.com/post/react-testing-library-order/
+    const allOptions = getAllByTestId("ssd1-option-",  { exact: false });
+    for (let i = 0; i < allOptions.length - 1; i++) {
+      console.log("[i]" + allOptions[i].value);
+      console.log("[i+1]" + allOptions[i+1].value);
+      expect(allOptions[i].value < allOptions[i + 1].value).toBe(true);
+    }
+
+  });
+
+  test("sorts and puts hyphens in testids", () => {
     render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
@@ -88,7 +120,7 @@ describe("SingleSubjectDropdown tests", () => {
     expect(await screen.findByText("Subject Area")).toBeInTheDocument();
     expect(screen.getByText("ANTH - Anthropology")).toHaveAttribute(
       "data-testid",
-      "ssd1-option-0"
+      "ssd1-option-ANTH"
     );
   });
 
@@ -139,7 +171,7 @@ describe("SingleSubjectDropdown tests", () => {
       />
     );
 
-    const expectedKey = "ssd1-option-0";
+    const expectedKey = "ssd1-option-ANTH";
     await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
   });
 

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -48,7 +48,7 @@ describe("SingleSubjectDropdown tests", () => {
   });
 
   test("renders without crashing on three subjects", async () => {
-     const { getAllByTestId} = render(
+     render(
       <SingleSubjectDropdown
         subjects={[ 
           threeSubjects[2],
@@ -67,10 +67,12 @@ describe("SingleSubjectDropdown tests", () => {
 
     // Check that blanks are replaced with hyphens
     await waitFor(() => expect(screen.getByTestId(ART_CS).toBeInTheDocument));
+    await waitFor(() => expect(screen.getByTestId(ANTH).toBeInTheDocument));
+    await waitFor(() => expect(screen.getByTestId(ARTHI).toBeInTheDocument));
 
     // Check that the options are sorted
     // See: https://www.atkinsondev.com/post/react-testing-library-order/
-    const allOptions = getAllByTestId("ssd1-option-",  { exact: false });
+    const allOptions = screen.getAllByTestId("ssd1-option-",  { exact: false });
     for (let i = 0; i < allOptions.length - 1; i++) {
       console.log("[i]" + allOptions[i].value);
       console.log("[i+1]" + allOptions[i+1].value);

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -68,6 +68,13 @@ describe("HomePage tests", () => {
     userEvent.selectOptions(selectQuarter, "20211");
     const selectSubject = screen.getByLabelText("Subject Area");
 
+
+    const expectedKey = "BasicSearch.Subject-option-ANTH";
+
+    await waitFor(
+      () => expect(screen.getByTestId(expectedKey).toBeInTheDocument)
+    );
+
     expect(await screen.findByLabelText("Subject Area")).toHaveTextContent("ANTH");
 
     userEvent.selectOptions(selectSubject, "ANTH");

--- a/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
+++ b/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
@@ -63,8 +63,9 @@ describe("Section Searches Index Page tests", () => {
     userEvent.selectOptions(selectQuarter, "20222");
     const selectSubject = screen.getByLabelText("Subject Area");
 
-    expect(await screen.findByLabelText("Subject Area")).toHaveTextContent("ANTH");
-
+    const expectedKey = "BasicSearch.Subject-option-ANTH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
+    
     userEvent.selectOptions(selectSubject, "ANTH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");


### PR DESCRIPTION
In this PR, we make progress towards a job to update courses.

We add a backend endpoint, and a frontend form that allows the user to submit a job to update the MongoDb database for a single quarter and subject area.

This is a start towards eventually being able to do this for all subject areas for a range of quarters.

This PR only sets up placeholders; the actual logic to retrieve the courses and store them is not in place yet.