### PR TITLE
Pc update node version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM bellsoft/liberica-openjdk-alpine:17.0.2
 
 WORKDIR /app
 
-ENV NODE_VERSION=14.17.3
+ENV NODE_VERSION=16.20.0
 RUN apk add curl
 RUN apk add bash
 RUN apk add maven

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -35,6 +35,7 @@ public class Job {
 
     private String status;
 
-    @Column(columnDefinition="TEXT") // needed for long strings, i.e. log entries longer than 255 characters
+    // 1048576 is 2^20, which is the max size of a mediumtext in MySQL
+    @Column(columnDefinition="TEXT", length=1048576) // needed for long strings, i.e. log entries longer than 255 characters
     private String log;
 }


### PR DESCRIPTION
In this PR, we change the version of node in the Dockerfile used on Dokku to match the one that's specified in the frontend/package.json in the Engines section, v16.20.0

This PR also includes an update to fix a problem with the job logs, where the status column was being stored with a sql data type of `varchar(255)` instead of `text`.