### PR TITLE
pc - try making job log at least 1MB

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -35,6 +35,7 @@ public class Job {
 
     private String status;
 
-    @Column(columnDefinition="TEXT") // needed for long strings, i.e. log entries longer than 255 characters
+    // 1048576 is 2^20, which is the max size of a mediumtext in MySQL
+    @Column(columnDefinition="TEXT", length=1048576) // needed for long strings, i.e. log entries longer than 255 characters
     private String log;
 }


### PR DESCRIPTION
In this PR, we fix a problem where the Spring Data layer was ignoring the request to use column type `TEXT` for the job log status field.

The default of `VARCHAR(255)` is not enough; this field stores a large amount of text, and the jobs were crashing after the character limit was exceeded.
