### PR TITLE
pc - add update quarter for range from f22-6pm-courses

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -21,6 +21,13 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersSingleSubjectJob;
+
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJob;
+
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJobFactory;
+
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJobFactory;
 import edu.ucsb.cs156.courses.jobs.TestJob;
@@ -49,6 +56,12 @@ public class JobsController extends ApiController {
 
     @Autowired
     UpdateCourseDataWithQuarterJobFactory updateCourseDataWithQuarterJobFactory;
+
+    @Autowired
+    UpdateCourseDataRangeOfQuartersJobFactory updateCourseDataRangeOfQuartersJobFactory;
+
+    @Autowired
+    UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory updateCourseDataRangeOfQuartersSingleSubjectJobFactory;
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -100,4 +113,37 @@ public class JobsController extends ApiController {
 
         return jobService.runAsJob(updateCourseDataWithQuarterJob);
     }
+
+
+    @ApiOperation(value = "Launch Job to Update Course Data for range of quarters")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/updateCoursesRangeOfQuarters")
+    public Job launchUpdateCourseDataRangeOfQuartersJob(
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
+    ) {
+       
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = updateCourseDataRangeOfQuartersJobFactory.create(
+            start_quarterYYYYQ, end_quarterYYYYQ);
+
+        return jobService.runAsJob(updateCourseDataRangeOfQuartersJob);
+    }
+
+    @ApiOperation(value = "Launch Job to Update Course Data for a range of quarters for a single subject")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/updateCoursesRangeOfQuartersSingleSubject")
+    public Job launchUpdateCourseDataRangeOfQuartersSingleSubjectJob(
+        @ApiParam("subject area") @RequestParam String subjectArea,
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
+    ) {
+       
+        UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = 
+        updateCourseDataRangeOfQuartersSingleSubjectJobFactory.create(
+            subjectArea, start_quarterYYYYQ, end_quarterYYYYQ);
+
+        return jobService.runAsJob(updateCourseDataRangeOfQuartersSingleSubjectJob);
+    }
+
+
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJob.java
@@ -1,0 +1,85 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.models.Quarter;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+
+@AllArgsConstructor
+@Slf4j
+public class UpdateCourseDataRangeOfQuartersJob implements JobContextConsumer {
+
+    @Getter private String start_quarterYYYYQ;
+    @Getter private String end_quarterYYYYQ;
+    @Getter private UCSBCurriculumService ucsbCurriculumService;
+    @Getter private ConvertedSectionCollection convertedSectionCollection;
+    @Getter private List<String> subjects;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        List<Quarter> quarters = Quarter.quarterList(start_quarterYYYYQ, end_quarterYYYYQ);
+        for(Quarter quarter : quarters) {
+            String quarterYYYYQ = quarter.getYYYYQ();
+            for (String subjectArea : subjects) {
+                updateCourses(ctx, quarterYYYYQ, subjectArea, ucsbCurriculumService, convertedSectionCollection);
+            }
+        }
+    }
+
+    public static void updateCourses(
+        JobContext ctx, 
+        String quarterYYYYQ, 
+        String subjectArea, 
+        UCSBCurriculumService ucsbCurriculumService,
+        ConvertedSectionCollection convertedSectionCollection
+        ) throws JsonProcessingException {
+        ctx.log("Updating courses for [" + subjectArea + " " + quarterYYYYQ + "]");
+
+        List<ConvertedSection> convertedSections = ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ,
+                "A");
+
+        ctx.log("Found " + convertedSections.size() + " sections");
+        ctx.log("Storing in MongoDB Collection...");
+
+        int newSections = 0;
+        int updatedSections = 0;
+        int errors = 0;
+
+        for (ConvertedSection section : convertedSections) {
+            try {
+                String qtr = section.getCourseInfo().getQuarter();
+                String enrollCode =  section.getSection().getEnrollCode();
+                Optional<ConvertedSection> optionalSection = convertedSectionCollection
+                        .findOneByQuarterAndEnrollCode(qtr,enrollCode);
+                if (optionalSection.isPresent()) {
+                    ConvertedSection existingSection = optionalSection.get();
+                    existingSection.setCourseInfo(section.getCourseInfo());
+                    existingSection.setSection(section.getSection());
+                    convertedSectionCollection.save(existingSection);
+                    updatedSections++;
+                } else {
+                    convertedSectionCollection.save(section);
+                    newSections++;
+                }
+            } catch (Exception e) {
+                ctx.log("Error saving section: " + e.getMessage());
+                errors++;
+            }
+        }
+         
+        ctx.log(String.format("%d new sections saved, %d sections updated, %d errors", newSections, updatedSections,
+                errors));
+        ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJobFactory.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class UpdateCourseDataRangeOfQuartersJobFactory  {
+
+    @Autowired 
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    @Autowired
+    private ConvertedSectionCollection convertedSectionCollection;
+
+    @Autowired
+    private UCSBSubjectRepository subjectRepository;
+
+    public UpdateCourseDataRangeOfQuartersJob create(String start_quarterYYYYQ, String end_quarterYYYYQ) {
+        log.info("ucsbCurriculumService = " + ucsbCurriculumService);
+        log.info("convertedSectionCollection = " + convertedSectionCollection);
+
+        List<String> subjects = new ArrayList<String>();
+        Iterable<UCSBSubject> UCSBSubjects = subjectRepository.findAll();
+        for (UCSBSubject UCSBSubject : UCSBSubjects) {
+            subjects.add(UCSBSubject.getSubjectCode());
+        }
+        return new UpdateCourseDataRangeOfQuartersJob(start_quarterYYYYQ, end_quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection, subjects);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJob.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import java.util.List;
+import java.util.Optional;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.models.Quarter;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJob implements JobContextConsumer {
+
+    @Getter
+    private String subjectArea;
+    @Getter
+    private String start_quarterYYYYQ;
+    @Getter
+    private String end_quarterYYYYQ;
+    @Getter
+    private UCSBCurriculumService ucsbCurriculumService;
+    @Getter
+    private ConvertedSectionCollection convertedSectionCollection;
+   
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        List<Quarter> quarters = Quarter.quarterList(start_quarterYYYYQ, end_quarterYYYYQ);
+        for (Quarter quarter : quarters) {
+            String quarterYYYYQ = quarter.getYYYYQ();
+            UpdateCourseDataRangeOfQuartersJob.updateCourses(ctx, quarterYYYYQ, subjectArea, ucsbCurriculumService, convertedSectionCollection);
+        }
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+
+
+@Service
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory  {
+
+    @Autowired 
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    @Autowired
+    private ConvertedSectionCollection convertedSectionCollection;
+
+    public UpdateCourseDataRangeOfQuartersSingleSubjectJob create(String subjectArea, String start_quarterYYYYQ, String end_quarterYYYYQ) {
+     
+        return new UpdateCourseDataRangeOfQuartersSingleSubjectJob(subjectArea, start_quarterYYYYQ, end_quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -35,8 +35,12 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.User;
+
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory;
+
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
@@ -74,6 +78,13 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @MockBean
     UpdateCourseDataJobFactory updateCourseDataJobFactory;
+
+    @MockBean
+    UpdateCourseDataRangeOfQuartersJobFactory updateCourseDataRangeOfQuartersJobFactory;
+
+    @MockBean
+    UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory updateCourseDataRangeOfQuartersSingleSubjectJobFactory;
+
 
     @MockBean
     ConvertedSectionCollection convertedSectionCollection;
@@ -221,5 +232,37 @@ public class JobsControllerTests extends ControllerTestCase {
 
         assertNotNull(jobReturned.getStatus());
     }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_update_courses_range_of_quarters_job() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateCoursesRangeOfQuarters?start_quarterYYYYQ=20221&end_quarterYYYYQ=20222").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_update_courses_range_of_quarters_single_subject_job() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateCoursesRangeOfQuartersSingleSubject?subjectArea=CMPSC&start_quarterYYYYQ=20221&end_quarterYYYYQ=20222").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }
+
 
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJobFactoryTests.java
@@ -1,0 +1,105 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.context.annotation.Import;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.controllers.UCSBSubjectsController;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
+
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+@RestClientTest(UpdateCourseDataRangeOfQuartersJobFactory.class)
+@AutoConfigureDataJpa
+public class UpdateCourseDataRangeOfQuartersJobFactoryTests {
+
+    @MockBean
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @MockBean
+    UCSBSubjectsController subjectsController;
+
+    @MockBean
+    UCSBSubjectRepository ucsbSubjectRepository;
+
+    @Autowired
+    UpdateCourseDataRangeOfQuartersJobFactory updateCourseDataRangeOfQuartersJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+    
+        // arrange
+
+        UCSBSubject us1 = UCSBSubject.builder()
+                .subjectCode("ANTH")
+                .subjectTranslation("Anthropology")
+                .deptCode("ANTH")
+                .collegeCode("L&S")
+                .relatedDeptCode(null)
+                .inactive(false)
+                .build();
+
+        UCSBSubject us2 = UCSBSubject.builder()
+                .subjectCode("ART  CS")
+                .subjectTranslation("Art (Creative Studies)")
+                .deptCode("CRSTU")
+                .collegeCode("CRST")
+                .relatedDeptCode(null)
+                .inactive(false)
+                .build();
+
+        UCSBSubject us3 = UCSBSubject.builder()
+                .subjectCode("CH E")
+                .subjectTranslation("Chemical Engineering")
+                .deptCode("CNENG")
+                .collegeCode("ENGR")
+                .relatedDeptCode(null)
+                .inactive(false)
+                .build();
+
+        ArrayList<UCSBSubject> subjects = new ArrayList<>();
+        subjects.addAll(Arrays.asList(us1, us2, us3));
+
+        ArrayList<String> expectedSubjects = new ArrayList<>();
+        
+        for(UCSBSubject subject: subjects) {
+                expectedSubjects.add(subject.getSubjectCode());
+        }
+
+        
+        // Act
+        
+        
+        when(ucsbSubjectRepository.findAll()).thenReturn(subjects);
+        
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = updateCourseDataRangeOfQuartersJobFactory.create("20221", "20222");
+
+        // Assert
+
+        assertEquals("20221",updateCourseDataRangeOfQuartersJob.getStart_quarterYYYYQ());
+        assertEquals("20222",updateCourseDataRangeOfQuartersJob.getEnd_quarterYYYYQ());
+        assertEquals(ucsbCurriculumService,updateCourseDataRangeOfQuartersJob.getUcsbCurriculumService());
+        assertEquals(convertedSectionCollection,updateCourseDataRangeOfQuartersJob.getConvertedSectionCollection());
+        assertEquals(expectedSubjects,updateCourseDataRangeOfQuartersJob.getSubjects());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJobTests.java
@@ -1,0 +1,595 @@
+ package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+//import com.fasterxml.jackson.core.type.TypeReference;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+//import edu.ucsb.cs156.courses.documents.Section;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class UpdateCourseDataRangeOfQuartersJobTests {
+
+    @Mock
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @Mock
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @Mock
+    List<String> subjects;
+
+
+    @Test
+    void test_log_output_success() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("CMPSC");
+        subjects.add("MATH");
+        subjects.add("ANTH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> result = coursePage.convertedSections();
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20221", "20222", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20221"), eq("A"))).thenReturn(result);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20221"), eq("A"))).thenReturn(result);
+        when(ucsbCurriculumService.getConvertedSections(eq("ANTH"), eq("20221"), eq("A"))).thenReturn(result);
+        when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20222"), eq("A"))).thenReturn(result);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20222"), eq("A"))).thenReturn(result);
+        when(ucsbCurriculumService.getConvertedSections(eq("ANTH"), eq("20222"), eq("A"))).thenReturn(result);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(result);
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [CMPSC 20221]
+                Found 14 sections
+                Storing in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
+                Courses for [CMPSC 20221] have been updated
+                Updating courses for [MATH 20221]
+                Found 14 sections
+                Storing in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
+                Courses for [MATH 20221] have been updated
+                Updating courses for [ANTH 20221]
+                Found 14 sections
+                Storing in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20221] have been updated
+                Updating courses for [CMPSC 20222]
+                Found 14 sections
+                Storing in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
+                Courses for [CMPSC 20222] have been updated
+                Updating courses for [MATH 20222]
+                Found 14 sections
+                Storing in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
+                Courses for [MATH 20222] have been updated
+                Updating courses for [ANTH 20222]
+                Found 14 sections
+                Storing in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20222] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+        //assertEquals(subjects,updateCourseDataRangeOfQuartersJob.getSubjects());
+
+    }
+
+    @Test
+    void test_log_output_with_updates() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("ANTH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
+
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20221", "20222", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("ANTH"), eq("20221"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
+
+
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional).thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()),
+                eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(null);
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [ANTH 20221]
+                Found 3 sections
+                Storing in MongoDB Collection...
+                2 new sections saved, 1 sections updated, 0 errors
+                Courses for [ANTH 20221] have been updated
+                Updating courses for [ANTH 20222]
+                Found 0 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20222] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_updates_same_year_same_quarter() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("ANTH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
+
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20221", "20221", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("ANTH"), eq("20221"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
+
+
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional).thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()),
+                eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(null);
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [ANTH 20221]
+                Found 3 sections
+                Storing in MongoDB Collection...
+                2 new sections saved, 1 sections updated, 0 errors
+                Courses for [ANTH 20221] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_updates_same_year_start_bigger_than_end() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("ANTH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
+
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20222", "20221", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("ANTH"), eq("20221"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
+
+
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional).thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()),
+                eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(null);
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+        Updating courses for [ANTH 20222]
+        Found 0 sections
+        Storing in MongoDB Collection...
+        0 new sections saved, 0 sections updated, 0 errors
+        Courses for [ANTH 20222] have been updated
+        Updating courses for [ANTH 20221]
+        Found 3 sections
+        Storing in MongoDB Collection...
+        2 new sections saved, 1 sections updated, 0 errors
+        Courses for [ANTH 20221] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+
+    @Test
+    void test_log_output_with_updates_qtr_reset() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("ANTH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
+
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20224", "20231", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("ANTH"), eq("20224"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
+
+
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional).thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()),
+                eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(null);
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [ANTH 20224]
+                Found 3 sections
+                Storing in MongoDB Collection...
+                2 new sections saved, 1 sections updated, 0 errors
+                Courses for [ANTH 20224] have been updated
+                Updating courses for [ANTH 20231]
+                Found 0 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20231] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_updates_year_flipped() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("ANTH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
+
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20222", "20211", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("ANTH"), eq("20211"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
+
+
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional).thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()),
+                eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(null);
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [ANTH 20222]
+                Found 0 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20222] have been updated
+                Updating courses for [ANTH 20221]
+                Found 0 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20221] have been updated
+                Updating courses for [ANTH 20214]
+                Found 0 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20214] have been updated
+                Updating courses for [ANTH 20213]
+                Found 0 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20213] have been updated
+                Updating courses for [ANTH 20212]
+                Found 0 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 0 sections updated, 0 errors
+                Courses for [ANTH 20212] have been updated
+                Updating courses for [ANTH 20211]
+                Found 3 sections
+                Storing in MongoDB Collection...
+                2 new sections saved, 1 sections updated, 0 errors
+                Courses for [ANTH 20211] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_errors() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("MATH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithOneSection = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+
+        listWithOneSection.add(section0);
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20221", "20222", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        // Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        // Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20221"), eq("A")))
+                .thenReturn(listWithOneSection);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20222"), eq("A")))
+                .thenReturn(listWithOneSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [MATH 20221]
+                Found 1 sections
+                Storing in MongoDB Collection...
+                Error saving section: Testing Exception Handling!
+                0 new sections saved, 0 sections updated, 1 errors
+                Courses for [MATH 20221] have been updated
+                Updating courses for [MATH 20222]
+                Found 1 sections
+                Storing in MongoDB Collection...
+                Error saving section: Testing Exception Handling!
+                0 new sections saved, 0 sections updated, 1 errors
+                Courses for [MATH 20222] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_updating_to_new_values() throws Exception {
+
+        // Arrange
+
+        subjects = new ArrayList<String>();
+        subjects.add("MATH");
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithUpdatedSection = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        String quarter = section0.getCourseInfo().getQuarter();
+        String enrollCode = section0.getSection().getEnrollCode();
+
+        int oldEnrollment = section0.getSection().getEnrolledTotal();
+
+        ConvertedSection updatedSection = (ConvertedSection) section0.clone();
+        updatedSection.getCourseInfo().setTitle("New Title");
+        updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
+        listWithUpdatedSection.add(updatedSection);
+
+        UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = new UpdateCourseDataRangeOfQuartersJob("20221", "20222", ucsbCurriculumService,
+                convertedSectionCollection, subjects);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20221"), eq("A")))
+                .thenReturn(listWithUpdatedSection);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20222"), eq("A")))
+                .thenReturn(listWithUpdatedSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
+                .thenReturn(section0Optional);
+
+        // Act
+
+        updateCourseDataRangeOfQuartersJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [MATH 20221]
+                Found 1 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 1 sections updated, 0 errors
+                Courses for [MATH 20221] have been updated
+                Updating courses for [MATH 20222]
+                Found 1 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 1 sections updated, 0 errors
+                Courses for [MATH 20222] have been updated""";
+
+         assertEquals(expected, jobStarted.getLog());
+
+       verify(convertedSectionCollection, times(2)).findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
+       verify(convertedSectionCollection, times(2)).save(updatedSection);
+
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactoryTests.java
@@ -1,0 +1,57 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.context.annotation.Import;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.controllers.UCSBSubjectsController;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
+
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+@RestClientTest(UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory.class)
+@AutoConfigureDataJpa
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJobFactoryTests {
+
+    @MockBean
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @Autowired
+    UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory updateCourseDataRangeOfQuartersSingleSubjectJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+            
+        // Act
+        
+        UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = updateCourseDataRangeOfQuartersSingleSubjectJobFactory.create("CMPSC", "20221", "20222");
+
+        // Assert
+
+        assertEquals("CMPSC",updateCourseDataRangeOfQuartersSingleSubjectJob.getSubjectArea());
+        assertEquals("20221",updateCourseDataRangeOfQuartersSingleSubjectJob.getStart_quarterYYYYQ());
+        assertEquals("20222",updateCourseDataRangeOfQuartersSingleSubjectJob.getEnd_quarterYYYYQ());
+        assertEquals(ucsbCurriculumService,updateCourseDataRangeOfQuartersSingleSubjectJob.getUcsbCurriculumService());
+        assertEquals(convertedSectionCollection,updateCourseDataRangeOfQuartersSingleSubjectJob.getConvertedSectionCollection());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobTests.java
@@ -1,0 +1,93 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+//import com.fasterxml.jackson.core.type.TypeReference;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+//import edu.ucsb.cs156.courses.documents.Section;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJobTests {
+
+        @Mock
+        UCSBCurriculumService ucsbCurriculumService;
+
+        @Mock
+        ConvertedSectionCollection convertedSectionCollection;
+
+        @Mock
+        List<String> subjects;
+
+        @Test
+        void test_log_output_success() throws Exception {
+
+                // Arrange
+
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+                CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+                List<ConvertedSection> result = coursePage.convertedSections();
+
+                UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = new UpdateCourseDataRangeOfQuartersSingleSubjectJob(
+                                "CMPSC", "20221", "20222", ucsbCurriculumService, convertedSectionCollection);
+
+                when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20221"), eq("A"))).thenReturn(result);
+                when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20222"), eq("A"))).thenReturn(result);
+                when(convertedSectionCollection.saveAll(any())).thenReturn(result);
+
+                // Act
+
+                updateCourseDataRangeOfQuartersSingleSubjectJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating courses for [CMPSC 20221]
+                                Found 14 sections
+                                Storing in MongoDB Collection...
+                                14 new sections saved, 0 sections updated, 0 errors
+                                Courses for [CMPSC 20221] have been updated
+                                Updating courses for [CMPSC 20222]
+                                Found 14 sections
+                                Storing in MongoDB Collection...
+                                14 new sections saved, 0 sections updated, 0 errors
+                                Courses for [CMPSC 20222] have been updated""";
+
+                assertEquals(expected, jobStarted.getLog());
+
+        }
+
+     
+}


### PR DESCRIPTION
In this PR, we add the backend for a new job that allows us to update the courses for a range of quarters.

# Screenshots

<img width="1494" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/cbca4b3c-4117-438e-8616-a66fd884e7c4">

The new part:

<img width="716" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/f315d2bf-0926-470a-ab96-53d0e9039a38">

<img width="707" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/44d4d1a8-d994-4c42-9982-25bbc335c68a">

What it looks like when it works:

<img width="814" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/d9e1e100-9243-41b4-bb10-20213165cf25">

<img width="802" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/4ceb94ad-add5-4fc8-a57a-1e2cbb3547ba">
lines omitted...
<img width="824" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/ee636af3-9fe1-4bd0-8551-51f5be443ca4">







