### PR TITLE
Brenna kaiwen course contrast

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,4 +19,8 @@ body {
     background-color: #34859b;
     border-color: #34859b;
   } 
-  
+
+  .btn-primary:hover{
+    background-color: #34859b;
+    border-color: #34859b;
+  } 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,3 +14,9 @@ body {
   .color-nav{
     background-color: rgb(0, 54, 96);
   } 
+
+  .btn-primary{
+    background-color: #34859b;
+    border-color: #34859b;
+  } 
+  

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,12 +15,9 @@ body {
     background-color: rgb(0, 54, 96);
   } 
 
-  .btn-primary{
+  .btn-primary, .btn-primary:hover, .btn-primary:focus{
     background-color: #34859b;
     border-color: #34859b;
   } 
 
-  .btn-primary:hover{
-    background-color: #34859b;
-    border-color: #34859b;
-  } 
+  

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -36,7 +36,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
             {
               systemInfo?.springH2ConsoleEnabled && (
                 <>
-                  <Nav.Link href="/h2-console">H2Console</Nav.Link>
+                  <Nav.Link href="/h2-console">H2Console </Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/components/SectionsOverTimeTableBase.js
+++ b/frontend/src/main/components/SectionsOverTimeTableBase.js
@@ -38,7 +38,7 @@ export default function SectionsOverTimeTableBase({ columns, data, testid = "tes
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                     // Stryker disable next-line ObjectLiteral
-                    style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
+                    style={{background: cell.isGrouped ? "#003660" : cell.isAggregated ? "#003660" : "#7490a6", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     
                     {cell.isGrouped ? (

--- a/frontend/src/main/components/SectionsOverTimeTableBase.js
+++ b/frontend/src/main/components/SectionsOverTimeTableBase.js
@@ -38,7 +38,7 @@ export default function SectionsOverTimeTableBase({ columns, data, testid = "tes
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                     // Stryker disable next-line ObjectLiteral
-                    style={{background: cell.isGrouped ? "#003660" : cell.isAggregated ? "#003660" : "#7490a6", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
+                    style={{background: cell.isGrouped ? "#34859b" : cell.isAggregated ? "#34859b" : "#9dbfbe", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     
                     {cell.isGrouped ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -37,7 +37,8 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <td
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                    style={{background: cell.isGrouped ? ( "#e5fcf4" ) : ( cell.isAggregated ? "#e5fcf4" : "#effcf8" ), fontWeight: cell.isGrouped ? ( "bold" ) : ( cell.isAggregated ? "bold" : "normal" )}}
+                    // Stryker disable next-line ObjectLiteral
+                    style={{background: cell.isGrouped ? "#34859b" : cell.isAggregated ? "#34859b" : "#9dbfbe", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     {cell.isGrouped ? (
                     <>

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -127,7 +127,7 @@ describe("SectionsTableBase tests", () => {
         expect(screen.getByText("➕")).toBeInTheDocument();
         expect(screen.queryByText("➖")).not.toBeInTheDocument();
         expect(screen.getByTestId("testid-cell-row-1-col-courseInfo.courseId-expand-symbols")).toBeInTheDocument();
-        expect(screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId")).toHaveAttribute("style", "background: rgb(229, 252, 244); font-weight: bold;");
+        expect(screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId")).toHaveAttribute("style", "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;");
 
     });
 })


### PR DESCRIPTION
Overview:

This PR copied from: https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/pull/26

In this PR, we changed the color of submit, login, and logout buttons to match the UCSB standard teal blue, including when hovering and clicking. We also changed the course history table and the main page section search to match the UCSB standard teal blue. 

Before: 
![Screen Shot 2023-05-30 at 2 06 31 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/f4a748fc-ce6c-414e-8f84-5e59d8e4c5f5)
![Screen Shot 2023-05-31 at 7 21 17 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/6ef82043-ba5b-43d7-90c3-055874548264)
![Screen Shot 2023-05-31 at 7 27 13 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/ac8dc906-6b79-4880-a1f9-01876cc1a50f)

After:
![Screen Shot 2023-05-31 at 7 19 13 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/a3ca4b15-91d2-4f96-a43b-e5ed684d131f)
![Screen Shot 2023-05-31 at 7 20 57 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/254eb70f-490a-4ea2-b5e9-330ad6ee55e9)
![Screen Shot 2023-05-31 at 7 27 53 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/9a352ecf-4aed-4d78-b223-bb67bba47aef)

Storybook link: https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-4/storybook/?path=/docs/components-courses-basiccoursetable--empty
