### PR TITLE
pc - change 'Course Infos' to 'Other Searches' on navbar

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -75,7 +75,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
 
 
             <Nav className="mr-auto">
-              <NavDropdown title="Course Infos" id="appnavbar-course-infos-dropdown" data-testid="appnavbar-course-infos-dropdown">
+              <NavDropdown title="Other Searches" id="appnavbar-course-infos-dropdown" data-testid="appnavbar-course-infos-dropdown">
                 <NavDropdown.Item href="/coursedescriptions/search" data-testid="appnavbar-course-descriptions-search">Course Descriptions</NavDropdown.Item>
                 <NavDropdown.Item href="/courseovertime/search" data-testid="appnavbar-course-over-time-search">Course History</NavDropdown.Item>
                 <NavDropdown.Item href="/courseovertime/buildingsearch" data-testid="appnavbar-course-over-time-buildings-search">Course Location History</NavDropdown.Item>


### PR DESCRIPTION
In this PR, we replace `Course Infos` on the navbar with `Other Searches`

We think this will help users more easily find the features of the website to accomplish their goals.

Current: [Storybook](https://ucsb-cs156.github.io/proj-courses/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)

<img width="1331" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/ca888d4a-e2ce-4c0a-8bab-6a9da4fa7015">


New: [Storybook](https://ucsb-cs156.github.io/proj-courses/prs/47/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)

<img width="875" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/202fb7eb-6d9c-44d2-b34b-efd6aed8e4c6">
