### PR TITLE
Fixed Springdocs end-quarter parameter vanishing

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -34,7 +34,7 @@ public class CourseOverTimeController {
     @GetMapping(value = "/search", produces = "application/json")
     public ResponseEntity<String> search(
         @Parameter(
-            name = "StartQtr",
+            name = "startQtr",
             description = "starting quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
             example = "20231",
             required = true

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -95,7 +95,7 @@ public class JobsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/launch/updateCourses")
     public Job launchUpdateCourseDataJob(
-        @Parameter(name="quarter (YYYYQ format)") @RequestParam String quarterYYYYQ,
+        @Parameter(name="quarterYYYYQ",description="quarter (YYYYQ format)") @RequestParam String quarterYYYYQ,
         @Parameter(name="subject area") @RequestParam String subjectArea
     ) {
        
@@ -110,7 +110,7 @@ public class JobsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/launch/updateQuarterCourses")
     public Job launchUpdateCourseDataWithQuarterJob(
-        @Parameter(name="quarter (YYYYQ format)") @RequestParam String quarterYYYYQ
+        @Parameter(name="quarterYYYYQ",description="quarter (YYYYQ format)") @RequestParam String quarterYYYYQ
     ) {
        
         UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = updateCourseDataWithQuarterJobFactory.create(
@@ -124,8 +124,8 @@ public class JobsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/launch/updateCoursesRangeOfQuarters")
     public Job launchUpdateCourseDataRangeOfQuartersJob(
-        @Parameter(name="start quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
-        @Parameter(name="end quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
+        @Parameter(name="start_quarterYYYYQ",description="start quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
+        @Parameter(name="end_quarterYYYYQ",description="end quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
     ) {
        
         UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = updateCourseDataRangeOfQuartersJobFactory.create(
@@ -138,9 +138,9 @@ public class JobsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/launch/updateCoursesRangeOfQuartersSingleSubject")
     public Job launchUpdateCourseDataRangeOfQuartersSingleSubjectJob(
-        @Parameter(name="subject area") @RequestParam String subjectArea,
-        @Parameter(name="start quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
-        @Parameter(name="end quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
+        @Parameter(name="subjectArea",description="subject area") @RequestParam String subjectArea,
+        @Parameter(name="start_quarterYYYYQ",description="start quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
+        @Parameter(name="end_quarterYYYYQ",description="end quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
     ) {
        
         UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -124,8 +124,8 @@ public class JobsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/launch/updateCoursesRangeOfQuarters")
     public Job launchUpdateCourseDataRangeOfQuartersJob(
-        @Parameter(name="quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
-        @Parameter(name="quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
+        @Parameter(name="start quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
+        @Parameter(name="end quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
     ) {
        
         UpdateCourseDataRangeOfQuartersJob updateCourseDataRangeOfQuartersJob = updateCourseDataRangeOfQuartersJobFactory.create(
@@ -139,8 +139,8 @@ public class JobsController extends ApiController {
     @PostMapping("/launch/updateCoursesRangeOfQuartersSingleSubject")
     public Job launchUpdateCourseDataRangeOfQuartersSingleSubjectJob(
         @Parameter(name="subject area") @RequestParam String subjectArea,
-        @Parameter(name="quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
-        @Parameter(name="quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
+        @Parameter(name="start quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
+        @Parameter(name="end quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
     ) {
        
         UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = 


### PR DESCRIPTION
# Overview

This PR implements a simple fix to give Springdocs unique names for the start and end quarter of certain Jobs Controllers.
This naming ambiguity was causing only one of the two parameters to appear in Springdocs.

# Issues Addressed
Before:
![image_720](https://github.com/ucsb-cs156/proj-courses/assets/28098845/769bef31-ee4a-4b57-a5f7-b6ed843c341f)


After:
![image](https://github.com/ucsb-cs156/proj-courses/assets/28098845/0aab9d04-32dd-43c2-ab42-5cb3b9980546)


# Notes

When converting from Springfox to Springdocs, make sure to double-check the following.
Make sure that @Parameter(name"...") matches the @RequestParam variable name

WRONG
@Parameter(name="StartQtr") @RequestParam String startQtr 

CORRECT
@Parameter(name="startQtr") @RequestParam String startQtr 

