### PR TITLE
Instructor search modified and "Lecture Only" checkbox

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Form, Button, Container, Row, Col } from "react-bootstrap";
+import { Form, Button, Container, Row, Col, FormCheck } from "react-bootstrap";
 import { quarterRange } from "main/utils/quarterUtilities";
 import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
@@ -19,20 +19,30 @@ const CourseOverTimeInstructorSearchForm = ({ fetchJSON }) => {
   const localStartQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.StartQuarter");
   const localEndQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.EndQuarter");
   const localInstructor = localStorage.getItem("CourseOverTimeInstructorSearch.Instructor");
+  const localStorageCheckbox = localStorage.getItem("CourseOverTimeInstructorSearch.Checkbox") === "true";
+  
 
   const [startQuarter, setStartQuarter] = useState(localStartQuarter || quarters[0].yyyyq);
   const [endQuarter, setEndQuarter] = useState(localEndQuarter || quarters[0].yyyyq);
   const [instructor, setInstructor] = useState(localInstructor || "");
+  const [checkbox, setCheckbox] = useState(localStorageCheckbox || false);
   // Stryker restore all
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { startQuarter, endQuarter, instructor });
+    fetchJSON(event, { startQuarter, endQuarter, instructor, checkbox });
   };
 
   const handleInstructorOnChange = (event) => {
     setInstructor(event.target.value);
-};
+  };
+
+  const handleCheckboxOnChange = (event) => {
+    setCheckbox(event.target.checked);
+    localStorage.setItem("CourseOverTimeInstructorSearch.Checkbox", event.target.checked.toString());
+  };
+
+  const testid = "CourseOverTimeInstructorSearchForm";
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -60,6 +70,9 @@ const CourseOverTimeInstructorSearchForm = ({ fetchJSON }) => {
         <Form.Group controlId="CourseOverTimeInstructorSearch.Instructor">
             <Form.Label>Instructor Name</Form.Label>
             <Form.Control onChange={handleInstructorOnChange} defaultValue={instructor} />
+        </Form.Group>
+        <Form.Group controlId="CourseOverTimeInstructorSearch.Checkbox">
+            <FormCheck data-testid={`${testid}-checkbox`} label="Lectures Only" onChange={handleCheckboxOnChange} checked={checkbox}></FormCheck>
         </Form.Group>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
           <Col md="auto">

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -14,6 +14,7 @@ export default function CourseOverTimeInstructorIndexPage() {
       startQtr: query.startQuarter,
       endQtr: query.endQuarter,
       instructor: query.instructor,
+      lectureOnly: query.checkbox,
     },
   });
 

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
@@ -26,6 +26,7 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
     jest.spyOn(console, 'error')
     console.error.mockImplementation(() => null);
 
@@ -94,7 +95,25 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
     userEvent.type(selectInstructor, "conrad");
     expect(selectInstructor.value).toBe("conrad");
   });
+  
+  
+  test("when I select the checkbox, the state for checkbox changes", () => {
+    jest.spyOn(Storage.prototype, 'setItem');
 
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectCheckbox = screen.getByTestId("CourseOverTimeInstructorSearchForm-checkbox");
+    userEvent.click(selectCheckbox);
+    expect(selectCheckbox.checked).toBe(true);
+    expect(localStorage.setItem).toBeCalledWith('CourseOverTimeInstructorSearch.Checkbox', "true");
+  });
+  
+  
   test("when I click submit, the right stuff happens", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {
@@ -102,9 +121,10 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
     };
 
     const fetchJSONSpy = jest.fn();
-
+    
+    
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
-
+    
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -112,33 +132,36 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
-
+    
     const expectedFields = {
       startQuarter: "20211",
       endQuarter: "20214",
       instructor: "CONRAD",
+      checkbox: true
     };
-
+    
     const selectStartQuarter = screen.getByLabelText("Start Quarter");
     userEvent.selectOptions(selectStartQuarter, "20211");
     const selectEndQuarter = screen.getByLabelText("End Quarter");
     userEvent.selectOptions(selectEndQuarter, "20214");
     const selectInstructor = screen.getByLabelText("Instructor Name");
     userEvent.type(selectInstructor, "CONRAD");
+    const selectCheckbox = screen.getByTestId("CourseOverTimeInstructorSearchForm-checkbox");
+    userEvent.click(selectCheckbox);
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
-
+    
     await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-
+    
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
       expectedFields
-    );
-  });
-
-  test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
-    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
-
+      );
+    });
+    
+    test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
+      axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+      
     const sampleReturnValue = {
       sampleKey: "sampleValue",
       total: 0,
@@ -162,6 +185,8 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
     userEvent.selectOptions(selectEndQuarter, "20204");
     const selectInstructor = screen.getByLabelText("Instructor Name");
     userEvent.type(selectInstructor, "conrad");
+    const selectCheckbox = screen.getByTestId("CourseOverTimeInstructorSearchForm-checkbox");
+    userEvent.click(selectCheckbox);
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
   });
@@ -205,5 +230,8 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
     const buttonRow = buttonCol.parentElement;
     expect(buttonRow).toHaveAttribute("style", "padding-top: 10px; padding-bottom: 10px;");
   });
+  
+
+
   
 });

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
@@ -67,6 +67,8 @@ describe("CourseOverTimeInstructorIndexPage tests", () => {
         userEvent.selectOptions(selectEndQuarter, "20222");
         const enterInstructor = screen.getByLabelText("Instructor Name")
         userEvent.type(enterInstructor, "CONRAD");
+        const selectCheckbox = screen.getByTestId("CourseOverTimeInstructorSearchForm-checkbox");
+        userEvent.click(selectCheckbox);
 
         const submitButton = screen.getByText("Submit");
         expect(submitButton).toBeInTheDocument();
@@ -82,6 +84,7 @@ describe("CourseOverTimeInstructorIndexPage tests", () => {
             startQtr: "20222",
             endQtr: "20222",
             instructor: "CONRAD",
+            lectureOnly: true,
         });
 
         expect(screen.getByText("ECE 1A")).toBeInTheDocument();

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -19,12 +19,13 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
         String startQuarter,
         String endQuarter,
         String courseId );
-        
-    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'section.instructors.instructor': {$regex: ?2, $options: 'i'} }")
+
+    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'section.instructors': { '$elemMatch': { 'instructor': { $regex: ?2 }, 'functionCode': { $regex: ?3 }}}}")
     List<ConvertedSection> findByQuarterRangeAndInstructor(
         String startQuarter,
         String endQuarter,
-        String instructor );
+        String instructor,
+        String functionCode );
     
      @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
      List<ConvertedSection> findByQuarterRangeAndBuildingCode(

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
@@ -54,14 +54,32 @@ public class CourseOverTimeInstructorController {
             example = "CONRAD",
             required = true
         )
-        @RequestParam String instructor
+        @RequestParam String instructor,
+        
+        @Parameter(
+            name = "lectureOnly", 
+            description = "Lectures only", 
+            example = "true", 
+            required = true
+        ) 
+        @RequestParam boolean lectureOnly
     ) throws JsonProcessingException {
-        List<ConvertedSection> courseResults = convertedSectionCollection.findByQuarterRangeAndInstructor(
-            startQtr,
-            endQtr,
-            instructor
-        );
+		List<ConvertedSection> courseResults;
+		if (lectureOnly) {
+			courseResults = convertedSectionCollection.findByQuarterRangeAndInstructor(
+				startQtr,
+				endQtr,
+				"^"+instructor.toUpperCase(),
+				"^(Teaching and in charge)");
+		} else {
+			courseResults = convertedSectionCollection.findByQuarterRangeAndInstructor(
+				startQtr,
+				endQtr,
+				"^"+instructor.toUpperCase(),
+				"^.*");
+		}
         String body = mapper.writeValueAsString(courseResults);
         return ResponseEntity.ok().body(body);
     }    
 }
+

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
@@ -47,7 +47,7 @@ public class CourseOverTimeInstructorControllerTests {
     @Test
     public void test_search_emptyRequest() throws Exception {
         List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
-        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
+        String urlTemplate = "/api/public/courseovertime/instructorsearch?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
         
         String url = String.format(urlTemplate, "20222", "20212", "CONRAD P T", "false");
 
@@ -92,23 +92,14 @@ public class CourseOverTimeInstructorControllerTests {
             .section(section2)
             .build();
 
-<<<<<<< HEAD:src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
-        String urlTemplate = "/api/public/courseovertime/instructorsearch?startQtr=%s&endQtr=%s&instructor=%s";
-    
-        String url = String.format(urlTemplate, "20222", "20222", "EMRE");
-=======
-        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
+        String urlTemplate = "/api/public/courseovertime/instructorsearch?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
     
         String url = String.format(urlTemplate, "20222", "20222", "CONRAD P T", "false");
->>>>>>> 737de85ba (ac - fix tests):src/test/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorControllerTests.java
 
         List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
         expectedSecs.addAll(Arrays.asList(cs1, cs2));
 
         // mock
-<<<<<<< HEAD:src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
-        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("EMRE"))).thenReturn(expectedSecs);
-=======
         when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("^CONRAD P T"), eq("^.*"))).thenReturn(expectedSecs);
 
         // act
@@ -142,7 +133,7 @@ public class CourseOverTimeInstructorControllerTests {
             .section(section2)
             .build();
 
-        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
+        String urlTemplate = "/api/public/courseovertime/instructorsearch?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
     
         String url = String.format(urlTemplate, "20222", "20222", "CONRAD P T", "true");
 
@@ -151,7 +142,6 @@ public class CourseOverTimeInstructorControllerTests {
 
         // mock
         when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("^CONRAD P T"), eq("^(Teaching and in charge)"))).thenReturn(expectedSecs);
->>>>>>> 737de85ba (ac - fix tests):src/test/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorControllerTests.java
 
         // act
         MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
@@ -47,12 +47,12 @@ public class CourseOverTimeInstructorControllerTests {
     @Test
     public void test_search_emptyRequest() throws Exception {
         List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
-        String urlTemplate = "/api/public/courseovertime/instructorsearch?startQtr=%s&endQtr=%s&instructor=%s";
+        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
         
-        String url = String.format(urlTemplate, "20222", "20212", "paul");
+        String url = String.format(urlTemplate, "20222", "20212", "CONRAD P T", "false");
 
         // mock
-        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), any(String.class)))
+        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), any(String.class), any(String.class)))
             .thenReturn(expectedResult);
 
         // act
@@ -92,15 +92,66 @@ public class CourseOverTimeInstructorControllerTests {
             .section(section2)
             .build();
 
+<<<<<<< HEAD:src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
         String urlTemplate = "/api/public/courseovertime/instructorsearch?startQtr=%s&endQtr=%s&instructor=%s";
     
         String url = String.format(urlTemplate, "20222", "20222", "EMRE");
+=======
+        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
+    
+        String url = String.format(urlTemplate, "20222", "20222", "CONRAD P T", "false");
+>>>>>>> 737de85ba (ac - fix tests):src/test/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorControllerTests.java
 
         List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
         expectedSecs.addAll(Arrays.asList(cs1, cs2));
 
         // mock
+<<<<<<< HEAD:src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
         when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("EMRE"))).thenReturn(expectedSecs);
+=======
+        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("^CONRAD P T"), eq("^.*"))).thenReturn(expectedSecs);
+
+        // act
+        MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+        // assert
+        String expectedString = mapper.writeValueAsString(expectedSecs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedString, responseString);
+    }
+
+    @Test public void test_search_validRequestOnlyLectures() throws Exception {
+        CourseInfo info = CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   24 -1")
+            .title("OBJ ORIENTED DESIGN")
+            .description("Intro to object oriented design")
+            .build();
+        
+        Section section1 = new Section();
+
+        Section section2 = new Section();
+
+        ConvertedSection cs1 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section1)
+            .build();
+        
+        ConvertedSection cs2 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section2)
+            .build();
+
+        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
+    
+        String url = String.format(urlTemplate, "20222", "20222", "CONRAD P T", "true");
+
+        List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
+        expectedSecs.addAll(Arrays.asList(cs1, cs2));
+
+        // mock
+        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("^CONRAD P T"), eq("^(Teaching and in charge)"))).thenReturn(expectedSecs);
+>>>>>>> 737de85ba (ac - fix tests):src/test/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorControllerTests.java
 
         // act
         MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();


### PR DESCRIPTION
# Overview

Search by Instructor search style modified such that the search is case-insensitive and only matches from the start of the instructor's name.
Adds a "Lecture Only" checkbox to the Search By Instructor form.
Changes came from:
https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-2/pull/36
https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-2/pull/31

# Notes
https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-2/pull/36
The search by instructor API endpoint is now case-insensitive, only matches from the start of the instructor's name, and allows for only viewing lectures. The query should be fast since it anchors at the beginning of the string and does not use regex's case insensitivity flag (which should be good for autocomplete).



https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-2/pull/31
Description: Added checkbox to the search by instructor form that adds the functionality of choosing Lectures only to the results of the courses.

Storybook entry: https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-2/prs/31/storybook/?path=/docs/components-basiccoursesearch-coursebyinstructorsearch--default
![243826006-232d91fb-c7c9-457f-9d32-79f32463d250](https://github.com/ucsb-cs156/proj-courses/assets/28098845/7726e8ea-8c7d-4dcd-9bd0-ced346bc431c)
