### PR TITLE
pc - update workflow runs for code formatting, and for copying issues

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1.yml
@@ -112,7 +112,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -B -Dgcf.skip test jacoco:report verify
 
     - name: Upload to artifacts
       uses: actions/upload-artifact@v3.1.2
@@ -383,7 +383,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -B -Dgcf.skip test jacoco:report verify
  
     - name: Upload to artifacts
       uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -37,7 +37,7 @@ jobs:
         echo "pr_number=${pr_number}" >> "$GITHUB_ENV"   
 
     - name: Build with Maven
-      run: mvn -B test jacoco:report verify
+      run: mvn -B -Dgcf.skip test jacoco:report verify
 
     - name: Set path for github pages deploy when there is a PR num
       if: always() # always upload artifacts, even if tests fail

--- a/.github/workflows/15-backend-format.yml
+++ b/.github/workflows/15-backend-format.yml
@@ -22,3 +22,17 @@ jobs:
 
       - name: Check formatting with Maven
         run: mvn git-code-format:validate-code-format
+
+      - name: "IF THE STEP ABOVE FAILS ^^^ open this step for a hint"
+        if: failure() # Only run if the previous step failed
+        run: |
+          echo "*******************************************************************************"  >> "$GITHUB_STEP_SUMMARY"
+          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
+          echo "* If this job fails, it's because some of your code is improperly formatted.  *"  >> "$GITHUB_STEP_SUMMARY"
+          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
+          echo "* To fix it, try running this:                                                *"  >> "$GITHUB_STEP_SUMMARY"
+          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
+          echo "*     mvn git-code-format:format-code                                         *"  >> "$GITHUB_STEP_SUMMARY"                                                           *"  >> "$GITHUB_STEP_SUMMARY"
+          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
+          echo "*******************************************************************************"  >> "$GITHUB_STEP_SUMMARY"
+

--- a/.github/workflows/15-backend-format.yml
+++ b/.github/workflows/15-backend-format.yml
@@ -23,16 +23,15 @@ jobs:
       - name: Check formatting with Maven
         run: mvn git-code-format:validate-code-format
 
-      - name: "IF THE STEP ABOVE FAILS ^^^ open this step for a hint"
+      - name: "IF STEP ABOVE FAILS ^^^ you need: mvn git-code-format:format-code"
         if: failure() # Only run if the previous step failed
         run: |
-          echo "*******************************************************************************"  >> "$GITHUB_STEP_SUMMARY"
-          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
-          echo "* If this job fails, it's because some of your code is improperly formatted.  *"  >> "$GITHUB_STEP_SUMMARY"
-          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
-          echo "* To fix it, try running this:                                                *"  >> "$GITHUB_STEP_SUMMARY"
-          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
-          echo "*     mvn git-code-format:format-code                                         *"  >> "$GITHUB_STEP_SUMMARY"                                                           *"  >> "$GITHUB_STEP_SUMMARY"
-          echo "*                                                                             *"  >> "$GITHUB_STEP_SUMMARY"
-          echo "*******************************************************************************"  >> "$GITHUB_STEP_SUMMARY"
+          echo  '# Note :warning:'                               >> $GITHUB_STEP_SUMMARY
+          echo  ''                                               >> $GITHUB_STEP_SUMMARY
+          echo  'Some of your code is improperly formatted. '    >> $GITHUB_STEP_SUMMARY
+          echo  ''                                               >> $GITHUB_STEP_SUMMARY
+          echo  ' To fix it, try running this:               '    >> $GITHUB_STEP_SUMMARY
+          echo  ''                                                >> $GITHUB_STEP_SUMMARY
+          echo  '   `mvn git-code-format:format-code`        '    >> $GITHUB_STEP_SUMMARY 
+          echo  '                                            '    >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/40-check-production-build.yml
+++ b/.github/workflows/40-check-production-build.yml
@@ -31,6 +31,6 @@ jobs:
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
         PRODUCTION: true
-      run: mvn -DskipTests clean dependency:list install
+      run: mvn -DskipTests -Dgcf.skip clean dependency:list install
 
   

--- a/.github/workflows/98-copy-issue-by-number.yml
+++ b/.github/workflows/98-copy-issue-by-number.yml
@@ -9,6 +9,7 @@ name: 98 - Copy specific issue from starter repo (creates new issue)
 env:
     GH_TOKEN: ${{ github.token }}
     STARTER: https://github.com/ucsb-cs156/proj-courses
+    TAG: f23
 on:
   workflow_dispatch:
     inputs:
@@ -29,7 +30,7 @@ jobs:
         id: get-issues
         run: |
           number=${{ github.event.inputs.issue_number }}
-          GH_REPO=${{env.STARTER}} gh issue list -s open -l M23 --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
+          GH_REPO=${{env.STARTER}} gh issue list -s open -l ${{env.TAG}}} --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
           cat issues.json
           {
                echo 'issues<<THIS_IS_THIS_EOF_MARKER'


### PR DESCRIPTION
In this PR, we modify a few workflow runs:

* For workflow runs that use the `verify` phase to check jacoco code coverage goals, we add a flag so that we skip checking formatting.  This allows us to report code coverage compliance and formatting compliance independently in the CI/CD runs.
* For workflow 15 that checks the code formatting, we add a message letting user know what to do in case the format check fails.
* For workflow 98, we factor out the hardcoded tag for M23 (summer 2023) into an environment variable so that it can be more easily changed for future quarters.