### PR TITLE
pc - use database_url instead of jdbc_database_url

### DIFF
--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=${JDBC_DATABASE_URL}
+spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:${DATABASE_URL}
+spring.datasource.url=${DATABASE_URL/postgres:/jdbc:postgresql:}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=${DATABASE_URL}
+spring.datasource.url=jdbc:${DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=${DATABASE_URL/postgres:/jdbc:postgresql:}
+spring.datasource.url=${JDBC_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 


### PR DESCRIPTION
In this PR, we try using DATABASE_URL instead of JDBC_DATABASE_URL for dokku.