### PR TITLE
Pc fix GitHub info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
+# This relies on the dokku setting:
+#   dokku git:set appname keep-git-dir true
+
 COPY . /home/app
 RUN cd /home/app && git status && git log | head -50 ; exit 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm --version
 #   dokku git:set appname keep-git-dir true
 
 COPY . /home/app
-RUN cd /home/app && git status && git log | head -50 ; exit 0
+RUN cd /home/app && git status && git log | head -20 ; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-# This relies on the dokku setting:
+# This approach (copying entire directory including git info) 
+# relies on the dokku setting:
 #   dokku git:set appname keep-git-dir true
 
 COPY . /home/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add curl
 RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
+RUN apk add git
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -22,6 +23,7 @@ COPY frontend /home/app/frontend
 COPY src /home/app/src
 COPY lombok.config /home/app
 COPY pom.xml /home/app
+COPY .git /home/app/.git
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,11 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
-
 # This approach (copying entire directory including git info) 
 # relies on the dokku setting:
 #   dokku git:set appname keep-git-dir true
 
 COPY . /home/app
-RUN cd /home/app && git status && git log | head -20 ; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,9 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
-COPY .git /home/app/.git
+COPY . /home/app
+RUN ls -al /home/app ; exit 0
+RUN cd /home/app && git status; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN node --version
 RUN npm --version
 
 COPY . /home/app
-RUN ls -al /home/app ; exit 0
-RUN cd /home/app && git status; exit 0
+RUN cd /home/app && git status && git log; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN node --version
 RUN npm --version
 
 COPY . /home/app
-RUN cd /home/app && git status && git log; exit 0
+RUN cd /home/app && git status && git log | head 100; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN node --version
 RUN npm --version
 
 COPY . /home/app
-RUN cd /home/app && git status && git log | head 100; exit 0
+RUN cd /home/app && git status && git log | head -50 ; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/pom.xml
+++ b/pom.xml
@@ -268,23 +268,22 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.1</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
                         <goals>
                             <goal>revision</goal>
                         </goals>
+                        <phase>initialize</phase>
                     </execution>
                 </executions>
                 <configuration>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
-                    <verbose>false</verbose>
-                    <useNativeGit>true</useNativeGit>
-                    <dotGitDirectory> /var/lib/jenkins/gitcache/proj-courses-f23-7pm-2.git</dotGitDirectory>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -16,7 +16,8 @@ public class SystemInfo {
   private Boolean showSwaggerUILink;
   private String startQtrYYYYQ;
   private String endQtrYYYYQ;
-  private String sourceRepo;
+  private String sourceRepo; // user configured URL of the source repository for footer
+  private String remoteOriginUrl; // ground truth repo for commit
   private String commitMessage;
   private String branch;
   private String commitId;

--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -17,9 +17,7 @@ public class SystemInfo {
   private String startQtrYYYYQ;
   private String endQtrYYYYQ;
   private String sourceRepo; // user configured URL of the source repository for footer
-  private String remoteOriginUrl; // ground truth repo for commit
   private String commitMessage;
-  private String branch;
   private String commitId;
-  private String githubUrl;
+  private String githubUrl; // URL to the commit in the source repository
 }

--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -20,4 +20,5 @@ public class SystemInfo {
   private String commitMessage;
   private String branch;
   private String commitId;
+  private String githubUrl;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -49,6 +49,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .commitMessage(this.commitMessage)
             .branch(this.branch)
             .commitId(this.commitId)
+            .githubUrl(commitId != null && sourceRepo!= null ? sourceRepo + "/commit/" + commitId : null)
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -49,7 +49,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .sourceRepo(this.sourceRepo)
             .commitMessage(this.commitMessage)
             .commitId(this.commitId)
-            .githubUrl(githubUrl(sourceRepo, commitId))
+            .githubUrl(githubUrl(this.sourceRepo, this.commitId))
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -45,7 +45,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .sourceRepo(this.sourceRepo)
             .commitMessage(this.commitMessage)
             .commitId(this.commitId)
-            .githubUrl(commitId != null && sourceRepo!= null ? sourceRepo + "/commit/" + commitId : null)
+            .githubUrl(
+                commitId != null && sourceRepo != null ? sourceRepo + "/commit/" + commitId : null)
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -29,14 +29,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
   private String sourceRepo;
 
-  @Value("${git.remote.origin.url}")
-  private String remoteOriginUrl;
-
   @Value("${git.commit.message.short}")
   private String commitMessage;
-
-  @Value("${git.branch}")
-  private String branch;
 
   @Value("${git.commit.id}")
   private String commitId;
@@ -49,11 +43,9 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .startQtrYYYYQ(this.startQtrYYYYQ)
             .endQtrYYYYQ(this.endQtrYYYYQ)
             .sourceRepo(this.sourceRepo)
-            .remoteOriginUrl(this.remoteOriginUrl)
             .commitMessage(this.commitMessage)
-            .branch(this.branch)
             .commitId(this.commitId)
-            .githubUrl(commitId != null && remoteOriginUrl!= null ? remoteOriginUrl + "/commit/" + commitId : null)
+            .githubUrl(commitId != null && sourceRepo!= null ? sourceRepo + "/commit/" + commitId : null)
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -29,6 +29,9 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
   private String sourceRepo;
 
+  @Value("${git.remote.origin.url}")
+  private String remoteOriginUrl;
+
   @Value("${git.commit.message.short}")
   private String commitMessage;
 
@@ -46,10 +49,11 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .startQtrYYYYQ(this.startQtrYYYYQ)
             .endQtrYYYYQ(this.endQtrYYYYQ)
             .sourceRepo(this.sourceRepo)
+            .remoteOriginUrl(this.remoteOriginUrl)
             .commitMessage(this.commitMessage)
             .branch(this.branch)
             .commitId(this.commitId)
-            .githubUrl(commitId != null && sourceRepo!= null ? sourceRepo + "/commit/" + commitId : null)
+            .githubUrl(commitId != null && remoteOriginUrl!= null ? remoteOriginUrl + "/commit/" + commitId : null)
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -32,7 +32,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${git.commit.message.short:unknown}")
   private String commitMessage;
 
-  @Value("${git.commit.id.short:unknown}")
+  @Value("${git.commit.id.abbrev:unknown}")
   private String commitId;
 
   public static String githubUrl(String repo, String commit) {

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -29,10 +29,10 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
   private String sourceRepo;
 
-  @Value("${git.commit.message.short}")
+  @Value("${git.commit.message.short:unknown}")
   private String commitMessage;
 
-  @Value("${git.commit.id}")
+  @Value("${git.commit.id.short:unknown}")
   private String commitId;
 
   public static String githubUrl(String repo, String commit) {

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -49,7 +49,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .sourceRepo(this.sourceRepo)
             .commitMessage(this.commitMessage)
             .commitId(this.commitId)
-            .githubUrl(githubUrl(sourceRepo,commitId))
+            .githubUrl(githubUrl(sourceRepo, commitId))
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -35,6 +35,10 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${git.commit.id}")
   private String commitId;
 
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
+
   public SystemInfo getSystemInfo() {
     SystemInfo si =
         SystemInfo.builder()
@@ -45,8 +49,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
             .sourceRepo(this.sourceRepo)
             .commitMessage(this.commitMessage)
             .commitId(this.commitId)
-            .githubUrl(
-                commitId != null && sourceRepo != null ? sourceRepo + "/commit/" + commitId : null)
+            .githubUrl(githubUrl(sourceRepo,commitId))
             .build();
     log.info("getSystemInfo returns {}", si);
     return si;

--- a/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.courses.services;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.ucsb.cs156.courses.models.SystemInfo;
@@ -25,5 +27,14 @@ class SystemInfoServiceImplTests {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
+    assertEquals(si.getGithubUrl(),"https://github.com/ucsb-cs156/proj-courses/commit/${git.commit.id}");
+  }
+
+  @Test
+  void test_githubUrl() {
+    assertEquals(SystemInfoServiceImpl.githubUrl("https://github.com/ucsb-cs156/proj-courses","abcdef12345"),"https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null,null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x",null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null,"x"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
@@ -27,7 +27,9 @@ class SystemInfoServiceImplTests {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals(si.getGithubUrl(), "https://github.com/ucsb-cs156/proj-courses/commit/unknown");
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
   }
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
@@ -27,8 +27,7 @@ class SystemInfoServiceImplTests {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals(
-        si.getGithubUrl(), "https://github.com/ucsb-cs156/proj-courses/commit/${git.commit.id}");
+    assertEquals(si.getGithubUrl(), "https://github.com/ucsb-cs156/proj-courses/commit/unknown");
   }
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImplTests.java
@@ -27,14 +27,18 @@ class SystemInfoServiceImplTests {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals(si.getGithubUrl(),"https://github.com/ucsb-cs156/proj-courses/commit/${git.commit.id}");
+    assertEquals(
+        si.getGithubUrl(), "https://github.com/ucsb-cs156/proj-courses/commit/${git.commit.id}");
   }
 
   @Test
   void test_githubUrl() {
-    assertEquals(SystemInfoServiceImpl.githubUrl("https://github.com/ucsb-cs156/proj-courses","abcdef12345"),"https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
-    assertNull(SystemInfoServiceImpl.githubUrl(null,null));
-    assertNull(SystemInfoServiceImpl.githubUrl("x",null));
-    assertNull(SystemInfoServiceImpl.githubUrl(null,"x"));
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
   }
 }


### PR DESCRIPTION
# Overview

In this PR, we update the Dockerfile so that the git-commit-id-maven-plugin works properly on Dokku.

We also update the version, and make the information about the git commit at /api/systemInfo more useful.


Note that this requires a setting in dokku, namely:

```
  dokku git:set appname keep-git-dir true
```

# Issues Addressed

Previously the git-commit-id-maven-plugin only worked on localhost.  Now it will work on dokku as well.

Before:

<img width="544" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/51dbeeaa-773f-49d0-946f-2c70b022fdd1">

After: 

<img width="609" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/1119017/c9b5ed01-9480-4f88-9cbb-eed139449368">


We removed branch name because it is misleading: it always shows `main` regardless of the branch deployed to dokku via git:sync, because the way dokku works under the hood, the "remote" for the repo in the Docker container is not the original repo, but rather a locally implemented repo using plain git via the file system.    Instead, we rely on the commit id.

Also note that the url for the repo does NOT come from github, and regrettably, there doesn't seem to be a way to get that information.  It will need to be set by the user via the environment variable `SOURCE_REPO`, e.g.

```
dokku config:set courses SOURCE_REPO=https://github.com/ucsb-cs156/proj-courses
```

Or for a student team:

```
dokku config:set courses SOURCE_REPO=https://github.com/ucsb-cs156-s24/s24-5pm-1-proj-courses
```
# Links

Compare
* <https://courses.dokku-00.cs.ucsb.edu/api/systemInfo>  Current Prod
* <https://courses-qa.dokku-00.cs.ucsb.edu/api/systemInfo> Current QA site



