### PR TITLE
Pc issue27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.3.2</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.ucsb.cs156</groupId>
@@ -41,10 +41,13 @@
 
         <!--
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-mongodb -->
+        <!--
+        https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-mongodb -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
+
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -88,12 +91,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-         <!-- Spring Doc for Spring Boot 3 https://springdoc.org/ -->
+        <!-- Spring Doc for Spring Boot 3 https://springdoc.org/ -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>
-        </dependency>   
+        </dependency>
 
         <dependency>
             <groupId>javax.validation</groupId>
@@ -116,7 +119,7 @@
             <artifactId>spring-security-config</artifactId>
         </dependency>
 
-          <!-- http://opencsv.sourceforge.net/ -->
+        <!-- http://opencsv.sourceforge.net/ -->
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
@@ -218,7 +221,7 @@
                     </historyOutputFile>
                     <verbose>true</verbose>
                     <targetClasses>
-                         <param>${targetClasses}</param>
+                        <param>${targetClasses}</param>
                     </targetClasses>
                     <targetTests>
                         <param>edu.ucsb.cs156.*</param>
@@ -375,19 +378,19 @@
                         <artifactId>maven-antrun-plugin</artifactId>
                         <version>3.0.0</version>
                         <executions>
-                        <execution>
-                            <phase>generate-resources</phase>
-                            <configuration>
-                            <target>
-                                <copy todir="${project.build.outputDirectory}/public">
-                                <fileset dir="${project.basedir}/frontend/build" />
-                                </copy>
-                            </target>
-                            </configuration>
-                            <goals>
-                            <goal>run</goal>
-                            </goals>
-                        </execution>
+                            <execution>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <copy todir="${project.build.outputDirectory}/public">
+                                            <fileset dir="${project.basedir}/frontend/build" />
+                                        </copy>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -9,13 +9,16 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 
 @SpringBootApplication
 @EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
+@EnableMongoAuditing(dateTimeProviderRef = "utcDateTimeProvider")
 // enables automatic population of @CreatedDate and @LastModifiedDate
+
 @EnableAsync // for @Async annotation for JobsService
 public class CoursesApplication {
 

--- a/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
@@ -1,6 +1,9 @@
 package edu.ucsb.cs156.courses.collections;
 
 import edu.ucsb.cs156.courses.documents.Update;
+
+import java.util.List;
+
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,12 +13,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UpdateCollection extends PagingAndSortingRepository<Update, ObjectId> {
   Update save(Update update);
-
   Page<Update> findBySubjectAreaAndQuarter(String subjectArea, String quarter, Pageable pageable);
-
   Page<Update> findByQuarter(String quarter, Pageable pageable);
-
   Page<Update> findBySubjectArea(String subjectArea, Pageable pageable);
-
   Page<Update> findAll(Pageable pageable);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
@@ -2,8 +2,6 @@ package edu.ucsb.cs156.courses.collections;
 
 import edu.ucsb.cs156.courses.documents.Update;
 
-import java.util.List;
-
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.Update;
 
-import edu.ucsb.cs156.courses.utilities.CourseUtilities;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
@@ -3,6 +3,8 @@ package edu.ucsb.cs156.courses.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.Update;
+
+import edu.ucsb.cs156.courses.utilities.CourseUtilities;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Data
@@ -20,5 +21,7 @@ public class Update {
   private int saved;
   private int updated;
   private int errors;
+
+  @LastModifiedDate
   private LocalDateTime lastUpdate;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -1,12 +1,21 @@
 package edu.ucsb.cs156.courses.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
 import java.time.ZonedDateTime;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -1,7 +1,9 @@
 package edu.ucsb.cs156.courses.jobs;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
@@ -19,6 +21,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
   private List<String> subjects;
   private UCSBCurriculumService ucsbCurriculumService;
   private ConvertedSectionCollection convertedSectionCollection;
+  private UpdateCollection updateCollection;
 
   @Override
   public void accept(JobContext ctx) throws Exception {
@@ -29,6 +32,12 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         updateCourses(ctx, quarterYYYYQ, subjectArea);
       }
     }
+  }
+
+  public Update updateUpdatesCollection(String quarterYYYYQ, String subjectArea, int saved, int updated, int errors) {
+    Update update = new Update(null, subjectArea, quarterYYYYQ, saved, updated, errors, null);
+    Update savedUpdate = updateCollection.save(update);
+    return savedUpdate;
   }
 
   public void updateCourses(JobContext ctx, String quarterYYYYQ, String subjectArea)
@@ -67,10 +76,13 @@ public class UpdateCourseDataJob implements JobContextConsumer {
       }
     }
 
+    Update savedUpdate = updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
+
     ctx.log(
         String.format(
-            "%d new sections saved, %d sections updated, %d errors",
-            newSections, updatedSections, errors));
+            "%d new sections saved, %d sections updated, %d errors, last update: %s",
+            newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
+    ctx.log("Saved update: " + savedUpdate);
     ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.jobs;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import java.util.ArrayList;
@@ -19,13 +20,16 @@ public class UpdateCourseDataJobFactory {
 
   @Autowired private UCSBSubjectRepository subjectRepository;
 
+  @Autowired private UpdateCollection updateCollection;
+
   public UpdateCourseDataJob createForSubjectAndQuarter(String subjectArea, String quarterYYYYQ) {
     return new UpdateCourseDataJob(
         quarterYYYYQ,
         quarterYYYYQ,
         List.of(subjectArea),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterRange(
@@ -35,7 +39,8 @@ public class UpdateCourseDataJobFactory {
         end_quarterYYYYQ,
         List.of(subjectArea),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 
   private List<String> getAllSubjectCodes() {
@@ -53,7 +58,8 @@ public class UpdateCourseDataJobFactory {
         quarterYYYYQ,
         getAllSubjectCodes(),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 
   public UpdateCourseDataJob createForQuarterRange(
@@ -63,6 +69,7 @@ public class UpdateCourseDataJobFactory {
         end_quarterYYYYQ,
         getAllSubjectCodes(),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/GradeHistoryRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/GradeHistoryRepository.java
@@ -2,11 +2,12 @@ package edu.ucsb.cs156.courses.repositories;
 
 import edu.ucsb.cs156.courses.entities.GradeHistory;
 import java.util.List;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
 @Repository
-public interface GradeHistoryRepository extends CrudRepository<GradeHistory, Long> {
+public interface GradeHistoryRepository extends JpaRepository<GradeHistory, Long> {
   public List<GradeHistory> findByYyyyqAndCourseAndInstructorAndGrade(
       String yyyyq, String course, String instructor, String grade);
 

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobsTest.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
@@ -26,6 +27,8 @@ public class UpdateCourseDataJobsTest {
 
   @Mock ConvertedSectionCollection convertedSectionCollection;
 
+  @Mock UpdateCollection updateCollection;
+
   Job jobStarted = Job.builder().build();
   JobContext ctx = new JobContext(null, jobStarted);
 
@@ -39,7 +42,7 @@ public class UpdateCourseDataJobsTest {
                 "20213",
                 List.of("CMPSC", "MATH"),
                 ucsbCurriculumService,
-                convertedSectionCollection));
+                convertedSectionCollection, updateCollection));
     doNothing().when(job).updateCourses(any(), any(), any());
 
     job.accept(ctx);
@@ -69,7 +72,7 @@ public class UpdateCourseDataJobsTest {
     // Act
     var job =
         new UpdateCourseDataJob(
-            "20211", "20211", List.of("CMPSC"), ucsbCurriculumService, convertedSectionCollection);
+            "20211", "20211", List.of("CMPSC"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
     job.accept(ctx);
 
     // Assert
@@ -120,7 +123,7 @@ public class UpdateCourseDataJobsTest {
     // Act
     var job =
         new UpdateCourseDataJob(
-            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection);
+            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
     job.accept(ctx);
 
     // Assert
@@ -164,7 +167,7 @@ public class UpdateCourseDataJobsTest {
     // Act
     var job =
         new UpdateCourseDataJob(
-            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection);
+            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
     job.accept(ctx);
 
     // Assert
@@ -214,7 +217,7 @@ public class UpdateCourseDataJobsTest {
     // Act
     var job =
         new UpdateCourseDataJob(
-            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection);
+            "20211", "20211", List.of("MATH"), ucsbCurriculumService,  convertedSectionCollection, updateCollection);
     job.accept(ctx);
 
     // Assert

--- a/src/test/java/edu/ucsb/cs156/courses/testconfig/TestConfig.java
+++ b/src/test/java/edu/ucsb/cs156/courses/testconfig/TestConfig.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.services.GrantedAuthoritiesService;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 
 @TestConfiguration
 @Import(SecurityConfig.class)
@@ -20,4 +21,14 @@ public class TestConfig {
   public GrantedAuthoritiesService grantedAuthoritiesService() {
     return new GrantedAuthoritiesService();
   }
+
+   /**
+   * This is needed because of the annotation EnableMongoAuditing on the main class.
+   * @returns a MongoMappingContext Bean
+   */
+  
+   @Bean
+   public MongoMappingContext mongoMappingContext() {
+     return new MongoMappingContext();
+   }
 }


### PR DESCRIPTION
# Overview

This PR contains code changes that help us make progress on issue #27 which is an issue to enable admins to see when data for a subject area and quarter was last updated.

# Details

In this PR, we update the Update.java entity with fields that are needed to keep track of when the Mongo Collection of course data is updated for particular subjectAreas and quarters.

We also add an annotation that enables MongoDB documents in a collection to have a last updated timestamp, along with the test configuration so that the needed bean exists in the test environment.

We also add a controller that enables us to see the records in the Update collection.