### PR TITLE
pc - update fields in Update.java to match naming conventions and add…

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
@@ -1,9 +1,18 @@
 package edu.ucsb.cs156.courses.collections;
 
 import edu.ucsb.cs156.courses.documents.Update;
+
 import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UpdateCollection extends MongoRepository<Update, ObjectId> {}
+public interface UpdateCollection extends PagingAndSortingRepository<Update, ObjectId> {
+  Update save(Update update);
+  Page<Update> findBySubjectAreaAndQuarter(String subjectArea, String quarter, Pageable pageable);
+  Page<Update> findByQuarter(String quarter, Pageable pageable);
+  Page<Update> findBySubjectArea(String subjectArea, Pageable pageable);
+  Page<Update> findAll(Pageable pageable);
+}

--- a/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/UpdateCollection.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.courses.collections;
 
 import edu.ucsb.cs156.courses.documents.Update;
-
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,8 +10,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UpdateCollection extends PagingAndSortingRepository<Update, ObjectId> {
   Update save(Update update);
+
   Page<Update> findBySubjectAreaAndQuarter(String subjectArea, String quarter, Pageable pageable);
+
   Page<Update> findByQuarter(String quarter, Pageable pageable);
+
   Page<Update> findBySubjectArea(String subjectArea, Pageable pageable);
+
   Page<Update> findAll(Pageable pageable);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
+import edu.ucsb.cs156.courses.documents.Update;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Updates", description = "API for course history updates")
+@RequestMapping("/api/updates")
+@RestController
+public class UpdateController extends ApiController {
+    @Autowired
+    UpdateCollection updateCollection;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Operation(summary = "Get updates for a subject area and quarter")
+    @GetMapping(value = "", produces = "application/json")
+    public Iterable<Update> getUpdates(
+            @Parameter(name = "subjectArea", description = "Course subject area code", example = "CMPSC", required = true) @RequestParam String subjectArea,
+            @Parameter(name = "quarter", description = "Quarter in yyyyq format", example = "20221", required = true) @RequestParam String quarter,
+            @Parameter(name = "page", description = "what page of the data", example = "0", required = true) @RequestParam int page,
+            @Parameter(name = "pageSize", description = "size of each page", example = "5", required = true) @RequestParam int pageSize) {
+        Iterable<Update> updates = null;
+        PageRequest pageRequest = PageRequest.of(page, pageSize, Direction.DESC, "lastUpdate");
+
+        if (subjectArea.toUpperCase().equals("ALL") &&
+            quarter.toUpperCase().equals("ALL")) {
+            updates = updateCollection.findAll(pageRequest);
+        } else if (subjectArea.toUpperCase().equals("ALL")) {
+            updates = updateCollection.findByQuarter(quarter, pageRequest);
+        } else if (quarter.toUpperCase().equals("ALL")) {
+            updates = updateCollection.findBySubjectArea(subjectArea, pageRequest);
+        } else {
+            updates = updateCollection.findBySubjectAreaAndQuarter(subjectArea, quarter, pageRequest);
+        }
+        log.info("updates: {}", updates);
+        return updates;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.Update;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,33 +20,54 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/updates")
 @RestController
 public class UpdateController extends ApiController {
-    @Autowired
-    UpdateCollection updateCollection;
+  @Autowired UpdateCollection updateCollection;
 
-    @Autowired
-    ObjectMapper mapper;
+  @Autowired ObjectMapper mapper;
 
-    @Operation(summary = "Get updates for a subject area and quarter")
-    @GetMapping(value = "", produces = "application/json")
-    public Iterable<Update> getUpdates(
-            @Parameter(name = "subjectArea", description = "Course subject area code", example = "CMPSC", required = true) @RequestParam String subjectArea,
-            @Parameter(name = "quarter", description = "Quarter in yyyyq format", example = "20221", required = true) @RequestParam String quarter,
-            @Parameter(name = "page", description = "what page of the data", example = "0", required = true) @RequestParam int page,
-            @Parameter(name = "pageSize", description = "size of each page", example = "5", required = true) @RequestParam int pageSize) {
-        Iterable<Update> updates = null;
-        PageRequest pageRequest = PageRequest.of(page, pageSize, Direction.DESC, "lastUpdate");
+  @Operation(summary = "Get updates for a subject area and quarter")
+  @GetMapping(value = "", produces = "application/json")
+  public Iterable<Update> getUpdates(
+      @Parameter(
+              name = "subjectArea",
+              description = "Course subject area code",
+              example = "CMPSC",
+              required = true)
+          @RequestParam
+          String subjectArea,
+      @Parameter(
+              name = "quarter",
+              description = "Quarter in yyyyq format",
+              example = "20221",
+              required = true)
+          @RequestParam
+          String quarter,
+      @Parameter(
+              name = "page",
+              description = "what page of the data",
+              example = "0",
+              required = true)
+          @RequestParam
+          int page,
+      @Parameter(
+              name = "pageSize",
+              description = "size of each page",
+              example = "5",
+              required = true)
+          @RequestParam
+          int pageSize) {
+    Iterable<Update> updates = null;
+    PageRequest pageRequest = PageRequest.of(page, pageSize, Direction.DESC, "lastUpdate");
 
-        if (subjectArea.toUpperCase().equals("ALL") &&
-            quarter.toUpperCase().equals("ALL")) {
-            updates = updateCollection.findAll(pageRequest);
-        } else if (subjectArea.toUpperCase().equals("ALL")) {
-            updates = updateCollection.findByQuarter(quarter, pageRequest);
-        } else if (quarter.toUpperCase().equals("ALL")) {
-            updates = updateCollection.findBySubjectArea(subjectArea, pageRequest);
-        } else {
-            updates = updateCollection.findBySubjectAreaAndQuarter(subjectArea, quarter, pageRequest);
-        }
-        log.info("updates: {}", updates);
-        return updates;
+    if (subjectArea.toUpperCase().equals("ALL") && quarter.toUpperCase().equals("ALL")) {
+      updates = updateCollection.findAll(pageRequest);
+    } else if (subjectArea.toUpperCase().equals("ALL")) {
+      updates = updateCollection.findByQuarter(quarter, pageRequest);
+    } else if (quarter.toUpperCase().equals("ALL")) {
+      updates = updateCollection.findBySubjectArea(subjectArea, pageRequest);
+    } else {
+      updates = updateCollection.findBySubjectAreaAndQuarter(subjectArea, quarter, pageRequest);
     }
+    log.info("updates: {}", updates);
+    return updates;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
@@ -15,7 +15,10 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "updates")
 public class Update {
   private ObjectId _id;
-  private String subject_area;
-  private String quarter_yyyyq;
-  private LocalDateTime last_update;
+  private String subjectArea;
+  private String quarter;
+  private int saved;
+  private int updated;
+  private int errors;
+  private LocalDateTime lastUpdate;
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UpdateControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UpdateControllerTests.java
@@ -1,22 +1,16 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.collections.UpdateCollection;
-import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.Update;
-import edu.ucsb.cs156.courses.entities.GradeHistory;
-import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -31,37 +25,38 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-@WebMvcTest(controllers = { UpdateController.class })
+@WebMvcTest(controllers = {UpdateController.class})
 @Import(TestConfig.class)
 @AutoConfigureDataJpa
 public class UpdateControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UpdateCollection updateCollection;
+  @MockBean UpdateCollection updateCollection;
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   ArrayList<Update> emptyArray = new ArrayList<Update>();
-  PageRequest pageRequest_0_10_DESC_lastUpdate = PageRequest.of(0, 10, Direction.DESC, "lastUpdate");
-  private final Page<Update> emptyPage_0_10_DESC_lastUpdate = new PageImpl<Update>(emptyArray, pageRequest_0_10_DESC_lastUpdate, 0);
+  PageRequest pageRequest_0_10_DESC_lastUpdate =
+      PageRequest.of(0, 10, Direction.DESC, "lastUpdate");
+  private final Page<Update> emptyPage_0_10_DESC_lastUpdate =
+      new PageImpl<Update>(emptyArray, pageRequest_0_10_DESC_lastUpdate, 0);
 
   @Test
-  @WithMockUser(roles = { "ADMIN" })
+  @WithMockUser(roles = {"ADMIN"})
   public void test_getUpdates_ALL_ALL_empty() throws Exception {
 
     // arrange
 
-    when(updateCollection.findAll(pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
+    when(updateCollection.findAll(pageRequest_0_10_DESC_lastUpdate))
+        .thenReturn(emptyPage_0_10_DESC_lastUpdate);
 
     // act
-    MvcResult response = mockMvc
-        .perform(get("/api/updates?subjectArea=ALL&quarter=ALL&page=0&pageSize=10"))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/updates?subjectArea=ALL&quarter=ALL&page=0&pageSize=10"))
+            .andExpect(status().isOk())
+            .andReturn();
 
     // assert
     String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
@@ -70,19 +65,20 @@ public class UpdateControllerTests extends ControllerTestCase {
   }
 
   @Test
-  @WithMockUser(roles = { "ADMIN" })
+  @WithMockUser(roles = {"ADMIN"})
   public void test_getUpdates_CMPSC_ALL_empty() throws Exception {
 
     // arrange
 
-    when(updateCollection.findBySubjectArea("CMPSC",pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
-
+    when(updateCollection.findBySubjectArea("CMPSC", pageRequest_0_10_DESC_lastUpdate))
+        .thenReturn(emptyPage_0_10_DESC_lastUpdate);
 
     // act
-    MvcResult response = mockMvc
-        .perform(get("/api/updates?subjectArea=CMPSC&quarter=ALL&page=0&pageSize=10"))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/updates?subjectArea=CMPSC&quarter=ALL&page=0&pageSize=10"))
+            .andExpect(status().isOk())
+            .andReturn();
 
     // assert
     String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
@@ -91,19 +87,20 @@ public class UpdateControllerTests extends ControllerTestCase {
   }
 
   @Test
-  @WithMockUser(roles = { "ADMIN" })
+  @WithMockUser(roles = {"ADMIN"})
   public void test_getUpdates_ALL_20221_empty() throws Exception {
 
     // arrange
 
-    when(updateCollection.findByQuarter( "20221",pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
-
+    when(updateCollection.findByQuarter("20221", pageRequest_0_10_DESC_lastUpdate))
+        .thenReturn(emptyPage_0_10_DESC_lastUpdate);
 
     // act
-    MvcResult response = mockMvc
-        .perform(get("/api/updates?subjectArea=ALL&quarter=20221&page=0&pageSize=10"))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/updates?subjectArea=ALL&quarter=20221&page=0&pageSize=10"))
+            .andExpect(status().isOk())
+            .andReturn();
 
     // assert
     String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
@@ -112,18 +109,21 @@ public class UpdateControllerTests extends ControllerTestCase {
   }
 
   @Test
-  @WithMockUser(roles = { "ADMIN" })
+  @WithMockUser(roles = {"ADMIN"})
   public void test_getUpdates_CMPSC_20221_empty() throws Exception {
 
     // arrange
 
-    when(updateCollection.findBySubjectAreaAndQuarter( "CMPSC","20221",pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
+    when(updateCollection.findBySubjectAreaAndQuarter(
+            "CMPSC", "20221", pageRequest_0_10_DESC_lastUpdate))
+        .thenReturn(emptyPage_0_10_DESC_lastUpdate);
 
     // act
-    MvcResult response = mockMvc
-        .perform(get("/api/updates?subjectArea=CMPSC&quarter=20221&page=0&pageSize=10"))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/updates?subjectArea=CMPSC&quarter=20221&page=0&pageSize=10"))
+            .andExpect(status().isOk())
+            .andReturn();
 
     // assert
     String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UpdateControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UpdateControllerTests.java
@@ -1,0 +1,133 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.Update;
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+import edu.ucsb.cs156.courses.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = { UpdateController.class })
+@Import(TestConfig.class)
+@AutoConfigureDataJpa
+public class UpdateControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UpdateCollection updateCollection;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  ArrayList<Update> emptyArray = new ArrayList<Update>();
+  PageRequest pageRequest_0_10_DESC_lastUpdate = PageRequest.of(0, 10, Direction.DESC, "lastUpdate");
+  private final Page<Update> emptyPage_0_10_DESC_lastUpdate = new PageImpl<Update>(emptyArray, pageRequest_0_10_DESC_lastUpdate, 0);
+
+  @Test
+  @WithMockUser(roles = { "ADMIN" })
+  public void test_getUpdates_ALL_ALL_empty() throws Exception {
+
+    // arrange
+
+    when(updateCollection.findAll(pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
+
+    // act
+    MvcResult response = mockMvc
+        .perform(get("/api/updates?subjectArea=ALL&quarter=ALL&page=0&pageSize=10"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // assert
+    String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponseAsJson, actualResponse);
+  }
+
+  @Test
+  @WithMockUser(roles = { "ADMIN" })
+  public void test_getUpdates_CMPSC_ALL_empty() throws Exception {
+
+    // arrange
+
+    when(updateCollection.findBySubjectArea("CMPSC",pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
+
+
+    // act
+    MvcResult response = mockMvc
+        .perform(get("/api/updates?subjectArea=CMPSC&quarter=ALL&page=0&pageSize=10"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // assert
+    String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponseAsJson, actualResponse);
+  }
+
+  @Test
+  @WithMockUser(roles = { "ADMIN" })
+  public void test_getUpdates_ALL_20221_empty() throws Exception {
+
+    // arrange
+
+    when(updateCollection.findByQuarter( "20221",pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
+
+
+    // act
+    MvcResult response = mockMvc
+        .perform(get("/api/updates?subjectArea=ALL&quarter=20221&page=0&pageSize=10"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // assert
+    String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponseAsJson, actualResponse);
+  }
+
+  @Test
+  @WithMockUser(roles = { "ADMIN" })
+  public void test_getUpdates_CMPSC_20221_empty() throws Exception {
+
+    // arrange
+
+    when(updateCollection.findBySubjectAreaAndQuarter( "CMPSC","20221",pageRequest_0_10_DESC_lastUpdate)).thenReturn(emptyPage_0_10_DESC_lastUpdate);
+
+    // act
+    MvcResult response = mockMvc
+        .perform(get("/api/updates?subjectArea=CMPSC&quarter=20221&page=0&pageSize=10"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // assert
+    String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponseAsJson, actualResponse);
+  }
+}


### PR DESCRIPTION
In this PR we make progress on issue #27 

We:

* Update field names in `Update.java` to match naming conventions and match the fields on the log output for the job that updates course data in the MongoDB collection