### PR TITLE
Keep track of when course update job is run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>courses</artifactId>
     <version>1.1.0</version>
     <name>courses</name>
-    <description>Starter for s22 courses search</description>
+    <description>UCSB CMPSC 156 Courses Search App</description>
     <properties>
         <java.version>17</java.version>
         <app.package>edu.ucsb.cs156.courses</app.package>
@@ -234,6 +234,7 @@
                         <param>${app.package}.config.CsrfCookieFilter</param>
                         <param>edu.ucsb.cs156.courses.config.SecurityConfig.MyCsrfRequestMatcher</param>
                         <param>edu.ucsb.cs156.courses.config.SpringFoxConfig</param>
+                        <param>edu.ucsb.cs156.courses.config.MongoConfig</param>
                     </excludedClasses>
                     <excludedTestClasses>
                         <param>edu.ucsb.cs156.example.integration.*</param>

--- a/src/main/java/edu/ucsb/cs156/courses/config/MongoConfig.java
+++ b/src/main/java/edu/ucsb/cs156/courses/config/MongoConfig.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.courses.config;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoRepositories("edu.ucsb.cs156.courses.collections")
+@EnableMongoAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+public class MongoConfig {
+
+    @Bean(name = "auditingDateTimeProvider")
+    public DateTimeProvider dateTimeProvider() {
+        return () -> Optional.of(OffsetDateTime.now());
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/config/MongoConfig.java
+++ b/src/main/java/edu/ucsb/cs156/courses/config/MongoConfig.java
@@ -2,7 +2,6 @@ package edu.ucsb.cs156.courses.config;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.auditing.DateTimeProvider;
@@ -14,9 +13,8 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 @EnableMongoAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 public class MongoConfig {
 
-    @Bean(name = "auditingDateTimeProvider")
-    public DateTimeProvider dateTimeProvider() {
-        return () -> Optional.of(OffsetDateTime.now());
-    }
-
+  @Bean(name = "auditingDateTimeProvider")
+  public DateTimeProvider dateTimeProvider() {
+    return () -> Optional.of(OffsetDateTime.now());
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Data
@@ -20,5 +21,7 @@ public class Update {
   private int saved;
   private int updated;
   private int errors;
+  
+  @LastModifiedDate
   private LocalDateTime lastUpdate;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Update.java
@@ -21,7 +21,6 @@ public class Update {
   private int saved;
   private int updated;
   private int errors;
-  
-  @LastModifiedDate
-  private LocalDateTime lastUpdate;
+
+  @LastModifiedDate private LocalDateTime lastUpdate;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -34,7 +34,8 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     }
   }
 
-  public Update updateUpdatesCollection(String quarterYYYYQ, String subjectArea, int saved, int updated, int errors) {
+  public Update updateUpdatesCollection(
+      String quarterYYYYQ, String subjectArea, int saved, int updated, int errors) {
     Update update = new Update(null, subjectArea, quarterYYYYQ, saved, updated, errors, null);
     Update savedUpdate = updateCollection.save(update);
     return savedUpdate;
@@ -76,7 +77,8 @@ public class UpdateCourseDataJob implements JobContextConsumer {
       }
     }
 
-    Update savedUpdate = updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
+    Update savedUpdate =
+        updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
 
     ctx.log(
         String.format(

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -1,7 +1,9 @@
 package edu.ucsb.cs156.courses.jobs;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
@@ -19,6 +21,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
   private List<String> subjects;
   private UCSBCurriculumService ucsbCurriculumService;
   private ConvertedSectionCollection convertedSectionCollection;
+  private UpdateCollection updateCollection;
 
   @Override
   public void accept(JobContext ctx) throws Exception {
@@ -29,6 +32,12 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         updateCourses(ctx, quarterYYYYQ, subjectArea);
       }
     }
+  }
+
+  public Update updateUpdatesCollection(String quarterYYYYQ, String subjectArea, int saved, int updated, int errors) {
+    Update update = new Update(null, subjectArea, quarterYYYYQ, saved, updated, errors, null);
+    Update savedUpdate = updateCollection.save(update);
+    return savedUpdate;
   }
 
   public void updateCourses(JobContext ctx, String quarterYYYYQ, String subjectArea)
@@ -67,10 +76,13 @@ public class UpdateCourseDataJob implements JobContextConsumer {
       }
     }
 
+    Update savedUpdate = updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
+
     ctx.log(
         String.format(
-            "%d new sections saved, %d sections updated, %d errors",
-            newSections, updatedSections, errors));
+            "%d new sections saved, %d sections updated, %d errors, last update: %s",
+            newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
+    ctx.log("Saved update: " + savedUpdate);
     ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.jobs;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import java.util.ArrayList;
@@ -19,13 +20,16 @@ public class UpdateCourseDataJobFactory {
 
   @Autowired private UCSBSubjectRepository subjectRepository;
 
+  @Autowired private UpdateCollection updateCollection;
+
   public UpdateCourseDataJob createForSubjectAndQuarter(String subjectArea, String quarterYYYYQ) {
     return new UpdateCourseDataJob(
         quarterYYYYQ,
         quarterYYYYQ,
         List.of(subjectArea),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterRange(
@@ -35,7 +39,8 @@ public class UpdateCourseDataJobFactory {
         end_quarterYYYYQ,
         List.of(subjectArea),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 
   private List<String> getAllSubjectCodes() {
@@ -53,7 +58,8 @@ public class UpdateCourseDataJobFactory {
         quarterYYYYQ,
         getAllSubjectCodes(),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 
   public UpdateCourseDataJob createForQuarterRange(
@@ -63,6 +69,7 @@ public class UpdateCourseDataJobFactory {
         end_quarterYYYYQ,
         getAllSubjectCodes(),
         curriculumService,
-        convertedSectionCollection);
+        convertedSectionCollection,
+        updateCollection);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.entities.UCSBSubject;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
@@ -21,6 +22,8 @@ public class UpdateCourseDataJobFactoryTests {
   @MockBean ConvertedSectionCollection convertedSectionCollection;
 
   @MockBean UCSBSubjectRepository ucsbSubjectRepository;
+
+  @MockBean UpdateCollection updateCollection;
 
   @Autowired UpdateCourseDataJobFactory factory;
 

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobsTest.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobsTest.java
@@ -6,12 +6,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -22,215 +26,231 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateCourseDataJobsTest {
-  @Mock UCSBCurriculumService ucsbCurriculumService;
+    @Mock
+    UCSBCurriculumService ucsbCurriculumService;
 
-  @Mock ConvertedSectionCollection convertedSectionCollection;
+    @Mock
+    ConvertedSectionCollection convertedSectionCollection;
 
-  Job jobStarted = Job.builder().build();
-  JobContext ctx = new JobContext(null, jobStarted);
+    @Mock
+    UpdateCollection updateCollection;
 
-  @Test
-  void test_subject_and_quarter_range() throws Exception {
+    Job jobStarted = Job.builder().build();
+    JobContext ctx = new JobContext(null, jobStarted);
 
-    var job =
-        spy(
-            new UpdateCourseDataJob(
-                "20211",
-                "20213",
-                List.of("CMPSC", "MATH"),
-                ucsbCurriculumService,
-                convertedSectionCollection));
-    doNothing().when(job).updateCourses(any(), any(), any());
+    @Test
+    void test_subject_and_quarter_range() throws Exception {
+        var job = spy(
+                new UpdateCourseDataJob(
+                        "20211",
+                        "20213",
+                        List.of("CMPSC", "MATH"),
+                        ucsbCurriculumService,
+                        convertedSectionCollection, updateCollection));
+        doNothing().when(job).updateCourses(any(), any(), any());
 
-    job.accept(ctx);
+        job.accept(ctx);
 
-    verify(job).updateCourses(ctx, "20211", "CMPSC");
-    verify(job).updateCourses(ctx, "20212", "CMPSC");
-    verify(job).updateCourses(ctx, "20213", "CMPSC");
+        verify(job).updateCourses(ctx, "20211", "CMPSC");
+        verify(job).updateCourses(ctx, "20212", "CMPSC");
+        verify(job).updateCourses(ctx, "20213", "CMPSC");
 
-    verify(job).updateCourses(ctx, "20211", "MATH");
-    verify(job).updateCourses(ctx, "20212", "MATH");
-    verify(job).updateCourses(ctx, "20213", "MATH");
-  }
+        verify(job).updateCourses(ctx, "20211", "MATH");
+        verify(job).updateCourses(ctx, "20212", "MATH");
+        verify(job).updateCourses(ctx, "20213", "MATH");
+    }
 
-  @Test
-  void test_log_output_success() throws Exception {
+    @Test
+    void test_log_output_success() throws Exception {
 
-    // Arrange
+        // Arrange
 
-    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-    List<ConvertedSection> result = coursePage.convertedSections();
+        List<ConvertedSection> result = coursePage.convertedSections();
 
-    when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A")))
-        .thenReturn(result);
+        when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A")))
+                .thenReturn(result);
 
-    // Act
-    var job =
-        new UpdateCourseDataJob(
-            "20211", "20211", List.of("CMPSC"), ucsbCurriculumService, convertedSectionCollection);
-    job.accept(ctx);
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        Update update = new Update(null, "CMPSC", "20211", 14, 0, 0, someTime);
+        when(updateCollection.save(any())).thenReturn(update);
 
-    // Assert
+        // Act
+        var job = new UpdateCourseDataJob(
+                "20211", "20211", List.of("CMPSC"), ucsbCurriculumService, convertedSectionCollection,
+                updateCollection);
+        job.accept(ctx);
 
-    String expected =
-        """
+        // Assert
+
+        String expected = """
                 Updating courses for [CMPSC 20211]
                 Found 14 sections
                 Storing in MongoDB Collection...
-                14 new sections saved, 0 sections updated, 0 errors
+                14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)
                 Courses for [CMPSC 20211] have been updated""";
 
-    assertEquals(expected, jobStarted.getLog());
-  }
+        assertEquals(expected, jobStarted.getLog());
+    }
 
-  @Test
-  void test_log_output_with_updates() throws Exception {
+    @Test
+    void test_log_output_with_updates() throws Exception {
 
-    // Arrange
+        // Arrange
 
-    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-    List<ConvertedSection> convertedSections = coursePage.convertedSections();
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
 
-    List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
 
-    ConvertedSection section0 = convertedSections.get(0);
-    ConvertedSection section1 = convertedSections.get(1);
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
 
-    listWithTwoOrigOneDuplicate.add(section0);
-    listWithTwoOrigOneDuplicate.add(section1);
-    listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
 
-    Optional<ConvertedSection> section0Optional = Optional.of(section0);
-    Optional<ConvertedSection> emptyOptional = Optional.empty();
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
 
-    when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
-        .thenReturn(listWithTwoOrigOneDuplicate);
-    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-            eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
-        .thenReturn(emptyOptional)
-        .thenReturn(section0Optional);
-    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-            eq(section1.getCourseInfo().getQuarter()), eq(section1.getSection().getEnrollCode())))
-        .thenReturn(emptyOptional);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional)
+                .thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()), eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
 
-    // Act
-    var job =
-        new UpdateCourseDataJob(
-            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection);
-    job.accept(ctx);
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        Update update = new Update(null, "MATH", "20211", 2, 1, 0, someTime);
+        when(updateCollection.save(any())).thenReturn(update);
 
-    // Assert
+        // Act
+        var job = new UpdateCourseDataJob(
+                "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
+        job.accept(ctx);
 
-    String expected =
-        """
+        // Assert
+
+        String expected = """
                 Updating courses for [MATH 20211]
                 Found 3 sections
                 Storing in MongoDB Collection...
-                2 new sections saved, 1 sections updated, 0 errors
+                2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)
                 Courses for [MATH 20211] have been updated""";
 
-    assertEquals(expected, jobStarted.getLog());
-  }
+        assertEquals(expected, jobStarted.getLog());
+    }
 
-  @Test
-  void test_log_output_with_errors() throws Exception {
+    @Test
+    void test_log_output_with_errors() throws Exception {
 
-    // Arrange
+        // Arrange
 
-    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-    List<ConvertedSection> convertedSections = coursePage.convertedSections();
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
 
-    List<ConvertedSection> listWithOneSection = new ArrayList<>();
+        List<ConvertedSection> listWithOneSection = new ArrayList<>();
 
-    ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section0 = convertedSections.get(0);
 
-    listWithOneSection.add(section0);
+        listWithOneSection.add(section0);
 
-    Optional<ConvertedSection> section0Optional = Optional.of(section0);
-    Optional<ConvertedSection> emptyOptional = Optional.empty();
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
 
-    when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
-        .thenReturn(listWithOneSection);
-    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-            eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
-        .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithOneSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
+                .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
 
-    // Act
-    var job =
-        new UpdateCourseDataJob(
-            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection);
-    job.accept(ctx);
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        Update update = new Update(null, "MATH", "20211", 0, 0, 1, someTime);
+        when(updateCollection.save(any())).thenReturn(update);
 
-    // Assert
+        // Act
+        var job = new UpdateCourseDataJob(
+                "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
+        job.accept(ctx);
 
-    String expected =
-        """
+        // Assert
+
+        String expected = """
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
                 Error saving section: Testing Exception Handling!
-                0 new sections saved, 0 sections updated, 1 errors
+                0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)
                 Courses for [MATH 20211] have been updated""";
 
-    assertEquals(expected, jobStarted.getLog());
-  }
+        assertEquals(expected, jobStarted.getLog());
+    }
 
-  @Test
-  void test_updating_to_new_values() throws Exception {
+    @Test
+    void test_updating_to_new_values() throws Exception {
 
-    // Arrange
+        // Arrange
 
-    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-    List<ConvertedSection> convertedSections = coursePage.convertedSections();
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
 
-    List<ConvertedSection> listWithUpdatedSection = new ArrayList<>();
+        List<ConvertedSection> listWithUpdatedSection = new ArrayList<>();
 
-    ConvertedSection section0 = convertedSections.get(0);
-    String quarter = section0.getCourseInfo().getQuarter();
-    String enrollCode = section0.getSection().getEnrollCode();
+        ConvertedSection section0 = convertedSections.get(0);
+        String quarter = section0.getCourseInfo().getQuarter();
+        String enrollCode = section0.getSection().getEnrollCode();
 
-    int oldEnrollment = section0.getSection().getEnrolledTotal();
+        int oldEnrollment = section0.getSection().getEnrolledTotal();
 
-    ConvertedSection updatedSection = (ConvertedSection) section0.clone();
-    updatedSection.getCourseInfo().setTitle("New Title");
-    updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
-    listWithUpdatedSection.add(updatedSection);
+        ConvertedSection updatedSection = (ConvertedSection) section0.clone();
+        updatedSection.getCourseInfo().setTitle("New Title");
+        updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
+        listWithUpdatedSection.add(updatedSection);
 
-    Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
 
-    when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
-        .thenReturn(listWithUpdatedSection);
-    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
-        .thenReturn(section0Optional);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithUpdatedSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
+                .thenReturn(section0Optional);
 
-    // Act
-    var job =
-        new UpdateCourseDataJob(
-            "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection);
-    job.accept(ctx);
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+        Update update = new Update(null, "MATH", "20211", 0, 1, 1, someTime);
+        when(updateCollection.save(any())).thenReturn(update);
 
-    // Assert
+        // Act
+        var job = new UpdateCourseDataJob(
+                "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
+        job.accept(ctx);
 
-    String expected =
-        """
+        // Assert
+
+        String expected = """
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
-                0 new sections saved, 1 sections updated, 0 errors
+                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
                 Courses for [MATH 20211] have been updated""";
 
-    assertEquals(expected, jobStarted.getLog());
+        assertEquals(expected, jobStarted.getLog());
 
-    verify(convertedSectionCollection, times(1))
-        .findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
-    verify(convertedSectionCollection, times(1)).save(updatedSection);
-  }
+        verify(convertedSectionCollection, times(1))
+                .findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
+        verify(convertedSectionCollection, times(1)).save(updatedSection);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobsTest.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobsTest.java
@@ -14,7 +14,6 @@ import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,66 +25,71 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateCourseDataJobsTest {
-    @Mock
-    UCSBCurriculumService ucsbCurriculumService;
+  @Mock UCSBCurriculumService ucsbCurriculumService;
 
-    @Mock
-    ConvertedSectionCollection convertedSectionCollection;
+  @Mock ConvertedSectionCollection convertedSectionCollection;
 
-    @Mock
-    UpdateCollection updateCollection;
+  @Mock UpdateCollection updateCollection;
 
-    Job jobStarted = Job.builder().build();
-    JobContext ctx = new JobContext(null, jobStarted);
+  Job jobStarted = Job.builder().build();
+  JobContext ctx = new JobContext(null, jobStarted);
 
-    @Test
-    void test_subject_and_quarter_range() throws Exception {
-        var job = spy(
-                new UpdateCourseDataJob(
-                        "20211",
-                        "20213",
-                        List.of("CMPSC", "MATH"),
-                        ucsbCurriculumService,
-                        convertedSectionCollection, updateCollection));
-        doNothing().when(job).updateCourses(any(), any(), any());
+  @Test
+  void test_subject_and_quarter_range() throws Exception {
+    var job =
+        spy(
+            new UpdateCourseDataJob(
+                "20211",
+                "20213",
+                List.of("CMPSC", "MATH"),
+                ucsbCurriculumService,
+                convertedSectionCollection,
+                updateCollection));
+    doNothing().when(job).updateCourses(any(), any(), any());
 
-        job.accept(ctx);
+    job.accept(ctx);
 
-        verify(job).updateCourses(ctx, "20211", "CMPSC");
-        verify(job).updateCourses(ctx, "20212", "CMPSC");
-        verify(job).updateCourses(ctx, "20213", "CMPSC");
+    verify(job).updateCourses(ctx, "20211", "CMPSC");
+    verify(job).updateCourses(ctx, "20212", "CMPSC");
+    verify(job).updateCourses(ctx, "20213", "CMPSC");
 
-        verify(job).updateCourses(ctx, "20211", "MATH");
-        verify(job).updateCourses(ctx, "20212", "MATH");
-        verify(job).updateCourses(ctx, "20213", "MATH");
-    }
+    verify(job).updateCourses(ctx, "20211", "MATH");
+    verify(job).updateCourses(ctx, "20212", "MATH");
+    verify(job).updateCourses(ctx, "20213", "MATH");
+  }
 
-    @Test
-    void test_log_output_success() throws Exception {
+  @Test
+  void test_log_output_success() throws Exception {
 
-        // Arrange
+    // Arrange
 
-        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-        List<ConvertedSection> result = coursePage.convertedSections();
+    List<ConvertedSection> result = coursePage.convertedSections();
 
-        when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A")))
-                .thenReturn(result);
+    when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A")))
+        .thenReturn(result);
 
-        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-        Update update = new Update(null, "CMPSC", "20211", 14, 0, 0, someTime);
-        when(updateCollection.save(any())).thenReturn(update);
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    Update update = new Update(null, "CMPSC", "20211", 14, 0, 0, someTime);
+    when(updateCollection.save(any())).thenReturn(update);
 
-        // Act
-        var job = new UpdateCourseDataJob(
-                "20211", "20211", List.of("CMPSC"), ucsbCurriculumService, convertedSectionCollection,
-                updateCollection);
-        job.accept(ctx);
+    // Act
+    var job =
+        new UpdateCourseDataJob(
+            "20211",
+            "20211",
+            List.of("CMPSC"),
+            ucsbCurriculumService,
+            convertedSectionCollection,
+            updateCollection);
+    job.accept(ctx);
 
-        // Assert
+    // Assert
 
-        String expected = """
+    String expected =
+        """
                 Updating courses for [CMPSC 20211]
                 Found 14 sections
                 Storing in MongoDB Collection...
@@ -93,53 +97,60 @@ public class UpdateCourseDataJobsTest {
                 Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)
                 Courses for [CMPSC 20211] have been updated""";
 
-        assertEquals(expected, jobStarted.getLog());
-    }
+    assertEquals(expected, jobStarted.getLog());
+  }
 
-    @Test
-    void test_log_output_with_updates() throws Exception {
+  @Test
+  void test_log_output_with_updates() throws Exception {
 
-        // Arrange
+    // Arrange
 
-        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+    List<ConvertedSection> convertedSections = coursePage.convertedSections();
 
-        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+    List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
 
-        ConvertedSection section0 = convertedSections.get(0);
-        ConvertedSection section1 = convertedSections.get(1);
+    ConvertedSection section0 = convertedSections.get(0);
+    ConvertedSection section1 = convertedSections.get(1);
 
-        listWithTwoOrigOneDuplicate.add(section0);
-        listWithTwoOrigOneDuplicate.add(section1);
-        listWithTwoOrigOneDuplicate.add(section0);
+    listWithTwoOrigOneDuplicate.add(section0);
+    listWithTwoOrigOneDuplicate.add(section1);
+    listWithTwoOrigOneDuplicate.add(section0);
 
-        Optional<ConvertedSection> section0Optional = Optional.of(section0);
-        Optional<ConvertedSection> emptyOptional = Optional.empty();
+    Optional<ConvertedSection> section0Optional = Optional.of(section0);
+    Optional<ConvertedSection> emptyOptional = Optional.empty();
 
-        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
-                .thenReturn(listWithTwoOrigOneDuplicate);
-        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-                eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
-                .thenReturn(emptyOptional)
-                .thenReturn(section0Optional);
-        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-                eq(section1.getCourseInfo().getQuarter()), eq(section1.getSection().getEnrollCode())))
-                .thenReturn(emptyOptional);
+    when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+        .thenReturn(listWithTwoOrigOneDuplicate);
+    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+            eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
+        .thenReturn(emptyOptional)
+        .thenReturn(section0Optional);
+    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+            eq(section1.getCourseInfo().getQuarter()), eq(section1.getSection().getEnrollCode())))
+        .thenReturn(emptyOptional);
 
-        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-        Update update = new Update(null, "MATH", "20211", 2, 1, 0, someTime);
-        when(updateCollection.save(any())).thenReturn(update);
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    Update update = new Update(null, "MATH", "20211", 2, 1, 0, someTime);
+    when(updateCollection.save(any())).thenReturn(update);
 
-        // Act
-        var job = new UpdateCourseDataJob(
-                "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
-        job.accept(ctx);
+    // Act
+    var job =
+        new UpdateCourseDataJob(
+            "20211",
+            "20211",
+            List.of("MATH"),
+            ucsbCurriculumService,
+            convertedSectionCollection,
+            updateCollection);
+    job.accept(ctx);
 
-        // Assert
+    // Assert
 
-        String expected = """
+    String expected =
+        """
                 Updating courses for [MATH 20211]
                 Found 3 sections
                 Storing in MongoDB Collection...
@@ -147,46 +158,53 @@ public class UpdateCourseDataJobsTest {
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)
                 Courses for [MATH 20211] have been updated""";
 
-        assertEquals(expected, jobStarted.getLog());
-    }
+    assertEquals(expected, jobStarted.getLog());
+  }
 
-    @Test
-    void test_log_output_with_errors() throws Exception {
+  @Test
+  void test_log_output_with_errors() throws Exception {
 
-        // Arrange
+    // Arrange
 
-        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+    List<ConvertedSection> convertedSections = coursePage.convertedSections();
 
-        List<ConvertedSection> listWithOneSection = new ArrayList<>();
+    List<ConvertedSection> listWithOneSection = new ArrayList<>();
 
-        ConvertedSection section0 = convertedSections.get(0);
+    ConvertedSection section0 = convertedSections.get(0);
 
-        listWithOneSection.add(section0);
+    listWithOneSection.add(section0);
 
-        Optional<ConvertedSection> section0Optional = Optional.of(section0);
-        Optional<ConvertedSection> emptyOptional = Optional.empty();
+    Optional<ConvertedSection> section0Optional = Optional.of(section0);
+    Optional<ConvertedSection> emptyOptional = Optional.empty();
 
-        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
-                .thenReturn(listWithOneSection);
-        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-                eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
-                .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+    when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+        .thenReturn(listWithOneSection);
+    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+            eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
+        .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
 
-        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-        Update update = new Update(null, "MATH", "20211", 0, 0, 1, someTime);
-        when(updateCollection.save(any())).thenReturn(update);
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    Update update = new Update(null, "MATH", "20211", 0, 0, 1, someTime);
+    when(updateCollection.save(any())).thenReturn(update);
 
-        // Act
-        var job = new UpdateCourseDataJob(
-                "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
-        job.accept(ctx);
+    // Act
+    var job =
+        new UpdateCourseDataJob(
+            "20211",
+            "20211",
+            List.of("MATH"),
+            ucsbCurriculumService,
+            convertedSectionCollection,
+            updateCollection);
+    job.accept(ctx);
 
-        // Assert
+    // Assert
 
-        String expected = """
+    String expected =
+        """
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
@@ -195,51 +213,58 @@ public class UpdateCourseDataJobsTest {
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)
                 Courses for [MATH 20211] have been updated""";
 
-        assertEquals(expected, jobStarted.getLog());
-    }
+    assertEquals(expected, jobStarted.getLog());
+  }
 
-    @Test
-    void test_updating_to_new_values() throws Exception {
+  @Test
+  void test_updating_to_new_values() throws Exception {
 
-        // Arrange
+    // Arrange
 
-        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
-        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
 
-        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+    List<ConvertedSection> convertedSections = coursePage.convertedSections();
 
-        List<ConvertedSection> listWithUpdatedSection = new ArrayList<>();
+    List<ConvertedSection> listWithUpdatedSection = new ArrayList<>();
 
-        ConvertedSection section0 = convertedSections.get(0);
-        String quarter = section0.getCourseInfo().getQuarter();
-        String enrollCode = section0.getSection().getEnrollCode();
+    ConvertedSection section0 = convertedSections.get(0);
+    String quarter = section0.getCourseInfo().getQuarter();
+    String enrollCode = section0.getSection().getEnrollCode();
 
-        int oldEnrollment = section0.getSection().getEnrolledTotal();
+    int oldEnrollment = section0.getSection().getEnrolledTotal();
 
-        ConvertedSection updatedSection = (ConvertedSection) section0.clone();
-        updatedSection.getCourseInfo().setTitle("New Title");
-        updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
-        listWithUpdatedSection.add(updatedSection);
+    ConvertedSection updatedSection = (ConvertedSection) section0.clone();
+    updatedSection.getCourseInfo().setTitle("New Title");
+    updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
+    listWithUpdatedSection.add(updatedSection);
 
-        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+    Optional<ConvertedSection> section0Optional = Optional.of(section0);
 
-        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
-                .thenReturn(listWithUpdatedSection);
-        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
-                .thenReturn(section0Optional);
+    when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+        .thenReturn(listWithUpdatedSection);
+    when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
+        .thenReturn(section0Optional);
 
-        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-        Update update = new Update(null, "MATH", "20211", 0, 1, 1, someTime);
-        when(updateCollection.save(any())).thenReturn(update);
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    Update update = new Update(null, "MATH", "20211", 0, 1, 1, someTime);
+    when(updateCollection.save(any())).thenReturn(update);
 
-        // Act
-        var job = new UpdateCourseDataJob(
-                "20211", "20211", List.of("MATH"), ucsbCurriculumService, convertedSectionCollection, updateCollection);
-        job.accept(ctx);
+    // Act
+    var job =
+        new UpdateCourseDataJob(
+            "20211",
+            "20211",
+            List.of("MATH"),
+            ucsbCurriculumService,
+            convertedSectionCollection,
+            updateCollection);
+    job.accept(ctx);
 
-        // Assert
+    // Assert
 
-        String expected = """
+    String expected =
+        """
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
@@ -247,10 +272,10 @@ public class UpdateCourseDataJobsTest {
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
                 Courses for [MATH 20211] have been updated""";
 
-        assertEquals(expected, jobStarted.getLog());
+    assertEquals(expected, jobStarted.getLog());
 
-        verify(convertedSectionCollection, times(1))
-                .findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
-        verify(convertedSectionCollection, times(1)).save(updatedSection);
-    }
+    verify(convertedSectionCollection, times(1))
+        .findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
+    verify(convertedSectionCollection, times(1)).save(updatedSection);
+  }
 }


### PR DESCRIPTION
In this PR, we make more progress on issue #27 by adding code that updates the Update collection in MongoDB with a record of the subjectArea and quarter every time the job is run that updates a particular subject area and quarter in the MongoDB collection of converted sections.