### PR TITLE
pc - update description for Update API with more helpful examples (and make ALL the default)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
@@ -24,20 +24,20 @@ public class UpdateController extends ApiController {
 
   @Autowired ObjectMapper mapper;
 
-  @Operation(summary = "Get updates for a subject area and quarter")
+  @Operation(summary = "Get updates for a subject area and quarter (most recent first)")
   @GetMapping(value = "", produces = "application/json")
   public Iterable<Update> getUpdates(
       @Parameter(
               name = "subjectArea",
-              description = "Course subject area code",
-              example = "CMPSC",
+              description = "Course subject area code (e.g. CMPSC) or ALL for all subject areas",
+              example = "ALL",
               required = true)
           @RequestParam
           String subjectArea,
       @Parameter(
               name = "quarter",
-              description = "Quarter in yyyyq format",
-              example = "20221",
+              description = "Quarter in yyyyq format (e.g. 20221) or ALL for all quarters",
+              example = "ALL",
               required = true)
           @RequestParam
           String quarter,


### PR DESCRIPTION
In this PR, we update the description for the API endpoint in the Updates controller to make it clear that ALL is an option.

We also make ALL the default option.

Before:

<img width="622" alt="image" src="https://github.com/user-attachments/assets/8474bc87-e715-400a-ac08-3347b126f823">

After:

<img width="762" alt="image" src="https://github.com/user-attachments/assets/ae467c11-1dab-43f5-a05f-005f2c9cacf2">

