### PR TITLE
Pc issue120: add IsStaleService to determine when subjectArea/Quarter need to be updated.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-         <!-- Spring Doc for Spring Boot 3 https://springdoc.org/ -->
+        <!-- Spring Doc for Spring Boot 3 https://springdoc.org/ -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>
-        </dependency>   
+        </dependency>
 
         <dependency>
             <groupId>javax.validation</groupId>
@@ -116,7 +116,7 @@
             <artifactId>spring-security-config</artifactId>
         </dependency>
 
-          <!-- http://opencsv.sourceforge.net/ -->
+        <!-- http://opencsv.sourceforge.net/ -->
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
@@ -219,7 +219,7 @@
                     </historyOutputFile>
                     <verbose>true</verbose>
                     <targetClasses>
-                         <param>${targetClasses}</param>
+                        <param>${targetClasses}</param>
                     </targetClasses>
                     <targetTests>
                         <param>edu.ucsb.cs156.*</param>
@@ -378,19 +378,19 @@
                         <artifactId>maven-antrun-plugin</artifactId>
                         <version>3.0.0</version>
                         <executions>
-                        <execution>
-                            <phase>generate-resources</phase>
-                            <configuration>
-                            <target>
-                                <copy todir="${project.build.outputDirectory}/public">
-                                <fileset dir="${project.basedir}/frontend/build" />
-                                </copy>
-                            </target>
-                            </configuration>
-                            <goals>
-                            <goal>run</goal>
-                            </goals>
-                        </execution>
+                            <execution>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <copy todir="${project.build.outputDirectory}/public">
+                                            <fileset dir="${project.basedir}/frontend/build" />
+                                        </copy>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/src/main/java/edu/ucsb/cs156/courses/entities/UCSBAPIQuarter.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/UCSBAPIQuarter.java
@@ -33,7 +33,7 @@ public class UCSBAPIQuarter {
   private LocalDateTime lastDayToAddGrad; // example: 2024-09-13T00:00:00
   private LocalDateTime lastDayThirdWeek; // example: null
 
-  public static final String SAMPLE_QUARTER_JSON_M23 =
+  public static final String SAMPLE_QUARTER_JSON_M24 =
       """
                 {
                     "quarter": "20243",

--- a/src/main/java/edu/ucsb/cs156/courses/services/IsStaleService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/IsStaleService.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.courses.services;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("IsStaleService")
+@ConfigurationProperties
+public class IsStaleService {
+
+  public boolean isStale(String subjectArea, String quarterYYYYQ) {
+    return true;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/IsStaleService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/IsStaleService.java
@@ -1,6 +1,12 @@
 package edu.ucsb.cs156.courses.services;
 
+import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
+import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Service;
 
@@ -9,7 +15,55 @@ import org.springframework.stereotype.Service;
 @ConfigurationProperties
 public class IsStaleService {
 
-  public boolean isStale(String subjectArea, String quarterYYYYQ) {
-    return true;
+  @Value("#{new Integer('${app.courseDataStaleThresholdMinutes:1440}')}")
+  private Integer courseDataStaleThresholdMinutes;
+
+  @Autowired private UCSBAPIQuarterService ucsbApiQuarterService;
+  @Autowired private UCSBAPIQuarterRepository ucsbApiQuarterRepository;
+  @Autowired private UpdateService updateService;
+
+  public int getCourseDataStaleThresholdMinutes() {
+    return courseDataStaleThresholdMinutes;
+  }
+
+  /**
+   * Check if the data is stale for a given subject area and quarter
+   *
+   * @param subjectArea e.g. CMPSC
+   * @param quarterYYYYQ e.g. 20221 for Winter 2022
+   * @return true if the data is stale, false otherwise
+   * @throws Exception
+   */
+  public boolean isStale(String subjectArea, String quarterYYYYQ) throws Exception {
+
+    Optional<LocalDateTime> lastUpdateOptional =
+        updateService.getLastUpdate(subjectArea, quarterYYYYQ);
+    if (lastUpdateOptional.isEmpty()) {
+      return true; // no update found, so data has never been loaded
+    }
+    LocalDateTime lastUpdate = lastUpdateOptional.get();
+
+    String currentQuarterYYYYQ = ucsbApiQuarterService.getCurrentQuarterYYYYQ();
+
+    // is the quarter in the past?
+    if (quarterYYYYQ.compareTo(currentQuarterYYYYQ) < 0) {
+      // this quarter is in the past
+      // check if the last update was after last day of that quarter
+      Optional<UCSBAPIQuarter> optionalQuarter =
+          ucsbApiQuarterRepository.findByQuarter(quarterYYYYQ);
+      if (optionalQuarter.isEmpty()) {
+        return true; // quarter not found
+      }
+      // Data is stale if the last update was before the last day of the quarter
+      UCSBAPIQuarter quarter = optionalQuarter.get();
+      LocalDateTime lastDayOfQuarter = quarter.getLastDayOfSchedule();
+      return lastUpdate.isBefore(lastDayOfQuarter);
+    }
+    // This quarter is the current quarter or in the future
+    // So data becomes stale at last update + app.
+
+    LocalDateTime staleTime = lastUpdate.plusMinutes(courseDataStaleThresholdMinutes);
+    LocalDateTime now = LocalDateTime.now();
+    return now.isAfter(staleTime);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -50,6 +50,19 @@ public class UCSBAPIQuarterService {
   public static final String ALL_QUARTERS_ENDPOINT =
       "https://api.ucsb.edu/academics/quartercalendar/v1/quarters";
 
+  public String getStartQtrYYYYQ() {
+    return startQtrYYYYQ;
+  }
+
+  public String getEndQtrYYYYQ() {
+    return endQtrYYYYQ;
+  }
+
+  public String getCurrentQuarterYYYYQ() throws Exception {
+    UCSBAPIQuarter quarter = getCurrentQuarter();
+    return quarter.getQuarter();
+  }
+
   public UCSBAPIQuarter getCurrentQuarter() throws Exception {
     HttpHeaders headers = new HttpHeaders();
     headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));

--- a/src/main/java/edu/ucsb/cs156/courses/services/UpdateService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UpdateService.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.courses.services;
+
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
+import edu.ucsb.cs156.courses.documents.Update;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+
+@Service("UpdateService")
+@ConfigurationProperties
+public class UpdateService {
+  /**
+   * Get the last update for a given subject area and quarter
+   *
+   * @param updateCollection
+   * @param subjectArea
+   * @param quarterYYYYQ
+   * @return the last update
+   * @throws Exception
+   */
+  @Autowired private UpdateCollection updateCollection;
+
+  public Optional<LocalDateTime> getLastUpdate(String subjectArea, String quarterYYYYQ)
+      throws Exception {
+
+    PageRequest pageRequest_0_1_DESC_lastUpdate =
+        PageRequest.of(0, 1, Direction.DESC, "lastUpdate");
+
+    Page<Update> updatePage =
+        updateCollection.findBySubjectAreaAndQuarter(
+            subjectArea, quarterYYYYQ, pageRequest_0_1_DESC_lastUpdate);
+    if (updatePage.getTotalElements() == 0) {
+      return Optional.empty();
+    }
+    Update update = updatePage.getContent().get(0);
+    return Optional.of(update.getLastUpdate());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
@@ -42,7 +42,7 @@ public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
   public void test_currentQuarter() throws Exception {
 
     UCSBAPIQuarter expectedResult =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, UCSBAPIQuarter.class);
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     String url = "/api/public/currentQuarter";
 
@@ -63,7 +63,7 @@ public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
   public void test_allQuarters() throws Exception {
 
     UCSBAPIQuarter M23 =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, UCSBAPIQuarter.class);
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(M23);
@@ -90,7 +90,7 @@ public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
   public void test_loadQuarters() throws Exception {
 
     UCSBAPIQuarter M23 =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, UCSBAPIQuarter.class);
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(M23);

--- a/src/test/java/edu/ucsb/cs156/courses/services/IsStaleServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/IsStaleServiceTests.java
@@ -1,23 +1,185 @@
 package edu.ucsb.cs156.courses.services;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
+import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(value = IsStaleService.class)
-@TestPropertySource("classpath:application-development.properties")
+@TestPropertySource(
+    properties = {
+      "app.startQtrYYYYQ=20211",
+      "app.endQtrYYYYQ=20223",
+      "app.ucsb.api.consumer_key=fakeApiKey",
+      "app.courseDataStaleThresholdMinutes=1440"
+    })
 class IsStaleServiceTests {
 
   @Autowired private IsStaleService isStaleService;
+  @MockBean private UpdateService updateService;
+  @MockBean private UCSBAPIQuarterService ucsbApiQuarterService;
+  @MockBean private UCSBAPIQuarterRepository ucsbApiQuarterRepository;
+
+  private ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void isStale_test() {
+  void test_getCourseDataStaleThresholdMinutes() {
+    assertEquals(1440, isStaleService.getCourseDataStaleThresholdMinutes());
+  }
+
+  @Test
+  void test_getLastUpdate__no_update_exists__true() throws Exception {
+    when(updateService.getLastUpdate("CMPSC", "20221")).thenReturn(Optional.empty());
+    assertTrue(isStaleService.isStale("CMPSC", "20221"));
+  }
+
+  @Test
+  void test_getLastUpdate__update_exists__details_for_quarter_do_not_exist__default_to_stale()
+      throws Exception {
+    // arrange
+
+    int courseDataStaleThresholdMinutes = isStaleService.getCourseDataStaleThresholdMinutes();
+    UCSBAPIQuarter W21 =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .lastDayOfSchedule(LocalDateTime.of(2021, 3, 19, 0, 0))
+            .build();
+    LocalDateTime lastDayOfW21 = W21.getLastDayOfSchedule();
+    LocalDateTime lastUpdateTime = lastDayOfW21.minusMinutes(courseDataStaleThresholdMinutes + 1);
+
+    when(updateService.getLastUpdate("CMPSC", "20211")).thenReturn(Optional.of(lastUpdateTime));
+    when(ucsbApiQuarterService.getCurrentQuarterYYYYQ()).thenReturn("20212");
+    when(ucsbApiQuarterRepository.findByQuarter("20211")).thenReturn(Optional.empty());
+
+    // act / assert
+
     assertTrue(isStaleService.isStale("CMPSC", "20211"));
+  }
+
+  @Test
+  void test_getLastUpdate__update_exists__past_quarter__updated_before_end_of_quarter()
+      throws Exception {
+    // arrange
+
+    int courseDataStaleThresholdMinutes = isStaleService.getCourseDataStaleThresholdMinutes();
+    UCSBAPIQuarter W21 =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .lastDayOfSchedule(LocalDateTime.of(2021, 3, 19, 0, 0))
+            .build();
+    LocalDateTime lastDayOfW21 = W21.getLastDayOfSchedule();
+    LocalDateTime lastUpdateTime = lastDayOfW21.minusMinutes(courseDataStaleThresholdMinutes + 1);
+
+    when(updateService.getLastUpdate("CMPSC", "20211")).thenReturn(Optional.of(lastUpdateTime));
+    when(ucsbApiQuarterService.getCurrentQuarterYYYYQ()).thenReturn("20212");
+    when(ucsbApiQuarterRepository.findByQuarter("20211")).thenReturn(Optional.of(W21));
+
+    // act / assert
+
+    assertTrue(isStaleService.isStale("CMPSC", "20211"));
+  }
+
+  @Test
+  void test_getLastUpdate__update_exists__past_quarter__updated_after_end_of_quarter()
+      throws Exception {
+    // arrange
+
+    UCSBAPIQuarter W21 =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .lastDayOfSchedule(LocalDateTime.of(2021, 3, 19, 0, 0))
+            .build();
+    LocalDateTime lastDayOfW21 = W21.getLastDayOfSchedule();
+    LocalDateTime lastUpdateTime = lastDayOfW21.plusMinutes(1);
+
+    when(updateService.getLastUpdate("CMPSC", "20211")).thenReturn(Optional.of(lastUpdateTime));
+    when(ucsbApiQuarterService.getCurrentQuarterYYYYQ()).thenReturn("20212");
+    when(ucsbApiQuarterRepository.findByQuarter("20211")).thenReturn(Optional.of(W21));
+
+    // act / assert
+
+    assertFalse(isStaleService.isStale("CMPSC", "20211"));
+  }
+
+  @Test
+  void test_getLastUpdate__update_exists__current_quarter__recent_update() throws Exception {
+
+    int staleThresholdMinutes = isStaleService.getCourseDataStaleThresholdMinutes();
+
+    // arrange
+
+    // The quarter is the current quarter
+    // The last update was at least three update intervals before the end of the quarter
+    // The current time is one minute before the data becomes stale
+
+    UCSBAPIQuarter W21 =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .lastDayOfSchedule(LocalDateTime.of(2021, 3, 19, 0, 0))
+            .build();
+    LocalDateTime lastDayOfW21 = W21.getLastDayOfSchedule();
+    LocalDateTime lastUpdateTime = lastDayOfW21.minusMinutes(staleThresholdMinutes * 3);
+    LocalDateTime staleTime = lastUpdateTime.plusMinutes(staleThresholdMinutes);
+    LocalDateTime mockNow = staleTime.minusMinutes(1); // one minute before data becomes stale
+
+    when(updateService.getLastUpdate("CMPSC", "20211")).thenReturn(Optional.of(lastUpdateTime));
+    when(ucsbApiQuarterService.getCurrentQuarterYYYYQ()).thenReturn("20211");
+    when(ucsbApiQuarterRepository.findByQuarter("20211")).thenReturn(Optional.of(W21));
+
+    // act / assert
+
+    try (MockedStatic<LocalDateTime> mockNowStatic = Mockito.mockStatic(LocalDateTime.class)) {
+      mockNowStatic.when(LocalDateTime::now).thenReturn(mockNow);
+      assertFalse(isStaleService.isStale("CMPSC", "20211"));
+    }
+  }
+
+  @Test
+  void test_getLastUpdate__update_exists__current_quarter__not_a_recent_update() throws Exception {
+
+    int staleThresholdMinutes = isStaleService.getCourseDataStaleThresholdMinutes();
+
+    // arrange
+
+    // The quarter is the current quarter
+    // The last update was at least three update intervals before the end of the quarter
+    // The current time is one minute after the data becomes stale
+
+    UCSBAPIQuarter W21 =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .lastDayOfSchedule(LocalDateTime.of(2021, 3, 19, 0, 0))
+            .build();
+    LocalDateTime lastDayOfW21 = W21.getLastDayOfSchedule();
+    LocalDateTime lastUpdateTime = lastDayOfW21.minusMinutes(staleThresholdMinutes * 3);
+    LocalDateTime staleTime = lastUpdateTime.plusMinutes(staleThresholdMinutes);
+    LocalDateTime mockNow = staleTime.plusMinutes(1); // one minute after data becomes stale
+
+    when(updateService.getLastUpdate("CMPSC", "20211")).thenReturn(Optional.of(lastUpdateTime));
+    when(ucsbApiQuarterService.getCurrentQuarterYYYYQ()).thenReturn("20211");
+    when(ucsbApiQuarterRepository.findByQuarter("20211")).thenReturn(Optional.of(W21));
+
+    // act / assert
+
+    try (MockedStatic<LocalDateTime> mockNowStatic = Mockito.mockStatic(LocalDateTime.class)) {
+      mockNowStatic.when(LocalDateTime::now).thenReturn(mockNow);
+      assertTrue(isStaleService.isStale("CMPSC", "20211"));
+    }
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/services/IsStaleServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/IsStaleServiceTests.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.courses.services;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = IsStaleService.class)
+@TestPropertySource("classpath:application-development.properties")
+class IsStaleServiceTests {
+
+  @Autowired private IsStaleService isStaleService;
+
+  @Test
+  void isStale_test() {
+    assertTrue(isStaleService.isStale("CMPSC", "20211"));
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
@@ -50,9 +50,35 @@ public class UCSBAPIQuarterServiceTests {
   @Autowired private ObjectMapper objectMapper;
 
   @Test
+  public void test_getStartQtrYYYYQ() {
+    assertEquals("20211", service.getStartQtrYYYYQ());
+  } // the value of app.startQtrYYYYQ is configured using @TestPropertySource
+
+  @Test
+  public void test_getEndQtrYYYYQ() {
+    assertEquals("20223", service.getEndQtrYYYYQ());
+  } // the value of app.endQtrYYYYQ is configured using @TestPropertySource
+
+  @Test
+  public void test_getCurrentQuarterYYYYQ() throws Exception {
+    String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
+
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(
+            withSuccess(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, MediaType.APPLICATION_JSON));
+
+    assertEquals("20243", service.getCurrentQuarterYYYYQ());
+  }
+
+  @Test
   public void test_getCurrentQuarter() throws Exception {
     UCSBAPIQuarter expectedResult =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, UCSBAPIQuarter.class);
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
 
@@ -63,7 +89,7 @@ public class UCSBAPIQuarterServiceTests {
         .andExpect(header("ucsb-api-version", "1.0"))
         .andExpect(header("ucsb-api-key", apiKey))
         .andRespond(
-            withSuccess(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, MediaType.APPLICATION_JSON));
+            withSuccess(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, MediaType.APPLICATION_JSON));
 
     UCSBAPIQuarter result = service.getCurrentQuarter();
 
@@ -73,7 +99,7 @@ public class UCSBAPIQuarterServiceTests {
   @Test
   public void test_getAllQuartersFromAPI() throws Exception {
     UCSBAPIQuarter sampleQuarter =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, UCSBAPIQuarter.class);
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(sampleQuarter);
@@ -97,7 +123,7 @@ public class UCSBAPIQuarterServiceTests {
   @Test
   public void test_getAllQuarters_preloaded() throws Exception {
     UCSBAPIQuarter sampleQuarter =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, UCSBAPIQuarter.class);
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(sampleQuarter);
@@ -117,7 +143,7 @@ public class UCSBAPIQuarterServiceTests {
     UCSBAPIQuarter W21 =
         objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
     UCSBAPIQuarter M23 =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M23, UCSBAPIQuarter.class);
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> emptyList = new ArrayList<UCSBAPIQuarter>();
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();

--- a/src/test/java/edu/ucsb/cs156/courses/services/UpdateServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UpdateServiceTests.java
@@ -1,0 +1,47 @@
+package edu.ucsb.cs156.courses.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import edu.ucsb.cs156.courses.collections.UpdateCollection;
+import edu.ucsb.cs156.courses.documents.Update;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = UpdateService.class)
+public class UpdateServiceTests {
+  @MockBean private UpdateCollection updateCollection;
+  @Autowired private UpdateService updateService;
+
+  @Test
+  public void test_getLastUpdate_nonEmpty() throws Exception {
+    LocalDateTime someDateTime = LocalDateTime.parse("2021-05-01T12:00:00");
+    when(updateCollection.findBySubjectAreaAndQuarter(
+            "CMPSC", "20221", PageRequest.of(0, 1, Direction.DESC, "lastUpdate")))
+        .thenReturn(new PageImpl<>(List.of(Update.builder().lastUpdate(someDateTime).build())));
+    Optional<LocalDateTime> optionalLastUpdate = updateService.getLastUpdate("CMPSC", "20221");
+    assertEquals(someDateTime, optionalLastUpdate.get());
+  }
+
+  @Test
+  public void test_getLastUpdate_empty() throws Exception {
+    LocalDateTime someDateTime = LocalDateTime.parse("2021-05-01T12:00:00");
+    when(updateCollection.findBySubjectAreaAndQuarter(
+            "CMPSC", "20221", PageRequest.of(0, 1, Direction.DESC, "lastUpdate")))
+        .thenReturn(new PageImpl<>(new ArrayList<Update>()));
+    Optional<LocalDateTime> optionalLastUpdate = updateService.getLastUpdate("CMPSC", "20221");
+    assertEquals(Optional.empty(), optionalLastUpdate);
+  }
+}


### PR DESCRIPTION
Closes issue #120 

In this PR, we add an "IsStaleService"  that, for any subject area / quarter:
* Consults the quarter table to see what the current quarter is, to determine whether this is a past quarter or a current/future quarter, and if it is a past quarter, what the last day of that quarter was.
* Consults the update table to see what the most recent update was (if any)
* Uses the rules in EPIC #116 to determine whether the data for the quarter is stale or not.

For more information, see: #116 

We also fix a typo in the name of a variable for the fixture `SAMPLE_QUARTER_JSON_M24` and add a couple of convenience methods to the UCSBAPIQuarterService.