### PR TITLE
pc - try adding a repeat to the deploy step in case it fails

### DIFF
--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -51,13 +51,19 @@ jobs:
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
     
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/jacoco # The folder where mvn puts the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/jacoco # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from
 
+        
 
   


### PR DESCRIPTION
In this PR, we try repeating the deploy step in github actions that deploy content to the gh-pages branch.

This step has often failed due to contention over the gh-pages branch.  The thought is that if we try the step 3 times with a 5 second sleep between attempts, that it might be successful more often.