### PR TITLE
pc - refactor stryker exception

### DIFF
--- a/frontend/src/main/components/Sections/SectionsInstructorTable.js
+++ b/frontend/src/main/components/Sections/SectionsInstructorTable.js
@@ -11,12 +11,11 @@ import {
 } from "main/utils/sectionUtils.js";
 
 export default function SectionsInstructorTable({ sections }) {
-  // Stryker enable all
-  // Stryker disable BooleanLiteral
   const columns = [
     {
       Header: "Quarter",
       accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       id: "quarter",
       Cell: ({ cell: { value } }) => value,
@@ -24,17 +23,20 @@ export default function SectionsInstructorTable({ sections }) {
     {
       Header: "Course ID",
       accessor: "courseInfo.courseId",
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       Cell: ({ cell: { value } }) => value.substring(0, value.length - 2),
     },
     {
       Header: "Title",
       accessor: "courseInfo.title",
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
     },
     {
       Header: "Status",
       accessor: (row) => formatStatus(row.section),
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       id: "status",
     },
@@ -42,36 +44,42 @@ export default function SectionsInstructorTable({ sections }) {
       Header: "Enrolled",
       accessor: (row) =>
         convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       id: "enrolled",
     },
     {
       Header: "Location",
       accessor: (row) => formatLocation(row.section.timeLocations),
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       id: "location",
     },
     {
       Header: "Days",
       accessor: (row) => formatDays(row.section.timeLocations),
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       id: "days",
     },
     {
       Header: "Time",
       accessor: (row) => formatTime(row.section.timeLocations),
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       id: "time",
     },
     {
       Header: "Instructor",
       accessor: (row) => formatInstructors(row.section.instructors),
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
       id: "instructor",
     },
     {
       Header: "Enroll Code",
       accessor: "section.enrollCode",
+      // Stryker disable next-line BooleanLiteral : TODO: Write a test that will check for whether this is set to true
       disableGroupBy: true,
     },
   ];


### PR DESCRIPTION
In this PR, we refactor the Stryker exceptions in `frontend/src/main/components/Sections/SectionsInstructorTable.js` as a prelude to issue #143 (which asks the dev to write better tests so that these exceptions are no longer needed.)