### PR TITLE
pc - add logging of query string

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/aop/LoggingAspect.java
+++ b/src/main/java/edu/ucsb/cs156/courses/aop/LoggingAspect.java
@@ -50,6 +50,9 @@ public class LoggingAspect {
                             request.getRequestURI(),
                             joinPoint.getSignature().getName(),
                             declaringTypeName));
+                if (request.getQueryString() != null) {
+                  log.info("===== Query String: %s".formatted(request.getQueryString()));
+                }
               }
             });
   }


### PR DESCRIPTION
In this PR, we add one line to the LoggingAspect which logs every controller request.

This line prints the query string, which helps in debugging cases when the param names or values in the query string sent by the frontend are not correct.

Example output:

```
2024-11-11T19:13:29.107-08:00  INFO 54004 --- [nio-8080-exec-8] e.ucsb.cs156.courses.aop.LoggingAspect   : ===== GET /api/public/courseovertime/search handled by search in edu.ucsb.cs156.courses.controllers.CourseOverTimeController
2024-11-11T19:13:29.107-08:00  INFO 54004 --- [nio-8080-exec-8] e.ucsb.cs156.courses.aop.LoggingAspect   : ===== Query String: startQtr=%2220214%22&endQtr=%2220212%22&subjectArea=%22ANTH%22&courseNumber=
20
```