### PR TITLE
pc/dj - streamline mongodb setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
             <artifactId>opencsv</artifactId>
             <version>5.7.1</version>
         </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
+            <version>4.18.0</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
                     <compilerArgument>-proc:full</compilerArgument>
-                    </configuration>
-                </plugin>
+                </configuration>
+            </plugin>
             <!-- Test case coverage report -->
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -356,6 +356,21 @@
             </dependencies>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>repackage</goal>
+                                </goals>
+                                <configuration>
+                                    <excludeGroupIds>de.flapdoodle,de.flapdoodle.embed,de.flapdoodle.graph,
+                                        de.flapdoodle.java8,de.flapdoodle.reverse</excludeGroupIds>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
                         <param>edu.ucsb.cs156.courses.config.SecurityConfig.MyCsrfRequestMatcher</param>
                         <param>edu.ucsb.cs156.courses.config.SpringFoxConfig</param>
                         <param>edu.ucsb.cs156.courses.config.MongoConfig</param>
+                        <param>edu.ucsb.cs156.courses.config.MongoDevConfig</param>
                     </excludedClasses>
                     <excludedTestClasses>
                         <param>edu.ucsb.cs156.example.integration.*</param>

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -13,7 +13,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 
-@SpringBootApplication
+@SpringBootApplication(excludeName = {"de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration"})
 @EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
 // enables automatic population of @CreatedDate and @LastModifiedDate
 @EnableAsync // for @Async annotation for JobsService

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -13,7 +13,8 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 
-@SpringBootApplication(excludeName = {"de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration"})
+@SpringBootApplication(
+    excludeName = {"de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration"})
 @EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
 // enables automatic population of @CreatedDate and @LastModifiedDate
 @EnableAsync // for @Async annotation for JobsService

--- a/src/main/java/edu/ucsb/cs156/courses/config/MongoConfig.java
+++ b/src/main/java/edu/ucsb/cs156/courses/config/MongoConfig.java
@@ -4,10 +4,12 @@ import java.time.OffsetDateTime;
 import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
+@Profile("production")
 @Configuration
 @EnableMongoRepositories("edu.ucsb.cs156.courses.collections")
 @EnableMongoAuditing(dateTimeProviderRef = "auditingDateTimeProvider")

--- a/src/main/java/edu/ucsb/cs156/courses/config/MongoDevConfig.java
+++ b/src/main/java/edu/ucsb/cs156/courses/config/MongoDevConfig.java
@@ -1,8 +1,8 @@
 package edu.ucsb.cs156.courses.config;
 
+import de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration;
 import java.time.OffsetDateTime;
 import java.util.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -12,21 +12,18 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
-import de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration;
 
 @Profile("development")
 @Configuration
 @EnableAutoConfiguration
 @EnableMongoRepositories("edu.ucsb.cs156.courses.collections")
 @EnableMongoAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
-public class MongoDevConfig extends EmbeddedMongoAutoConfiguration{
+public class MongoDevConfig extends EmbeddedMongoAutoConfiguration {
 
-    @Bean(name = "auditingDateTimeProvider")
-    public DateTimeProvider dateTimeProvider() {
-        return () -> Optional.of(OffsetDateTime.now());
-    }
+  @Bean(name = "auditingDateTimeProvider")
+  public DateTimeProvider dateTimeProvider() {
+    return () -> Optional.of(OffsetDateTime.now());
+  }
 
-    public void mongoInstance(@Autowired MongoTemplate mongoTemplate) {
-
-    }
+  public void mongoInstance(@Autowired MongoTemplate mongoTemplate) {}
 }

--- a/src/main/java/edu/ucsb/cs156/courses/config/MongoDevConfig.java
+++ b/src/main/java/edu/ucsb/cs156/courses/config/MongoDevConfig.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.courses.config;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration;
+
+@Profile("development")
+@Configuration
+@EnableAutoConfiguration
+@EnableMongoRepositories("edu.ucsb.cs156.courses.collections")
+@EnableMongoAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+public class MongoDevConfig extends EmbeddedMongoAutoConfiguration{
+
+    @Bean(name = "auditingDateTimeProvider")
+    public DateTimeProvider dateTimeProvider() {
+        return () -> Optional.of(OffsetDateTime.now());
+    }
+
+    public void mongoInstance(@Autowired MongoTemplate mongoTemplate) {
+
+    }
+}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -8,6 +8,10 @@ spring.h2.console.settings.web-allow-others=true
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
 
+de.flapdoodle.mongodb.embedded.version=7.0.12
+
+
+
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 
 spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:true}}

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -4,3 +4,5 @@ spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}
+
+spring.data.mongodb.uri=${MONGO_URL:${env.MONGO_URL:mongodb://localhost:27017/courses}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,8 +26,6 @@ server.compression.enabled=false
 
 #spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
 
-spring.data.mongodb.uri=${MONGO_URL:${env.MONGO_URL:mongodb://localhost:27017/courses}}
-
 spring.mvc.format.date-time=iso
 
 app.startQtrYYYYQ=${START_QTR:${env.START_QTR:20221}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,9 @@ app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/pro
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false
 
-spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
+#spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
+
+spring.data.mongodb.uri=${MONGO_URL:${env.MONGO_URL:mongodb://localhost:27017/courses}}
 
 spring.mvc.format.date-time=iso
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,8 +24,6 @@ app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/pro
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false
 
-#spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
-
 spring.mvc.format.date-time=iso
 
 app.startQtrYYYYQ=${START_QTR:${env.START_QTR:20221}}


### PR DESCRIPTION
In this PR, we:
* Streamline the specification of the URL for the MongoDB database to make deployment on dokku easier
* Add an "in memory" implementation of MongoDB for running in development and testing environments (similar to how the H2 environment is used for the SQL database.)

## Overview

When running on dokku, the new config variable is MONGO_URL instead of MONGO_URI, to match the config variable used by the `dokku mongo:create ...` command.   Now, configuring the app for Mongo on dokku is as simple as:

```
dokku mongo:create courses-m
dokku mongo:link courses-m courses
dokku ps:rebuild courses
```

When running on localhost, configuration of Mongo is no longer necessary; just as with the H2 database, configuration is automatic.

## Details

The definition of the MONGO_URL variable is moved to to `application-production.properties`. 

Additionally, we add `MongoDevConfig.java`, which runs an embedded MongoDB instance. It has a version configuration, which is currently set to 7.0.12 to mimic the Mongo Cluster.

Deployed at https://courses-qa.dokku-00.cs.ucsb.edu/

Referenced from: https://www.garretwilson.com/blog/2023/04/02/embedded-mongodb-ide-spring-boot-3

MongoDB collections can be viewed in `courses-qa-mongo` via `dokku mongo:connect courses-qa-mongo` with command `db.getCollectionNames()`