### PR TITLE
pc - improve handling of actions/setup-java in workflows

### DIFF
--- a/.github/workflows/01-gh-pages-pr-table.yml
+++ b/.github/workflows/01-gh-pages-pr-table.yml
@@ -74,9 +74,15 @@ jobs:
         mkdir -p site
         cp -r frontend/docs-index/* site
   
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        folder: site # The folder the action should deploy.
-        branch: gh-pages
-        clean: false # Automatically remove deleted files from the deploy branch
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          folder: site # The folder the action should deploy.
+          branch: gh-pages
+          clean: false # Automatically remove deleted files from the deploy branch
+

--- a/.github/workflows/02-gh-pages-rebuild-part-1.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1.yml
@@ -4,6 +4,9 @@ on:
 
 env:
   GH_TOKEN: ${{ github.token }}
+  # See: https://github.com/actions/setup-java#supported-distributions
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
 
 permissions:
   contents: write
@@ -49,8 +52,10 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc
@@ -125,8 +130,10 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Build with Maven
       continue-on-error: true
@@ -155,8 +162,11 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
+
     - name: create directories
       run: |
          mkdir -p ${{ env.destination }}
@@ -319,8 +329,10 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
-         java-version-file: ./.java-version
+          distribution: ${{ env.JAVA_DISTRIBUTION }} 
+          java-version-file: ./.java-version
+          cache: 'maven'
+          cache-dependency-path: 'pom.xml' 
 
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc
@@ -421,8 +433,10 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
-         java-version-file: ./.java-version
+          distribution: ${{ env.JAVA_DISTRIBUTION }} 
+          java-version-file: ./.java-version
+          cache: 'maven'
+          cache-dependency-path: 'pom.xml' 
 
     - name: Build with Maven
       continue-on-error: true
@@ -473,8 +487,10 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
 
     - name: Download artifact
       id: download-artifact

--- a/.github/workflows/04-gh-pages-redeploy-part-2.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2.yml
@@ -72,12 +72,17 @@ jobs:
         mkdir -p site
         cp -r frontend/docs-index/* site
         
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        folder: site # The folder the action should deploy.
-        branch: gh-pages
-        clean: true # Automatically remove deleted files from the deploy branch
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          folder: site # The folder the action should deploy.
+          branch: gh-pages
+          clean: true # Automatically remove deleted files from the deploy branch
 
   deploy-main-docs:
     name: Deploy Documentation for main branch

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -11,6 +11,10 @@ on:
     branches: [ main ]
     paths: [src/**, pom.xml, lombok.config]
 
+env:
+    # See: https://github.com/actions/setup-java#supported-distributions
+    JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+    
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,10 +23,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Build with Maven
       env:

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -6,10 +6,10 @@ name: "10-backend-unit: Java Unit tests"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/10-backend-unit.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/10-backend-unit.yml]
 
 env:
     # See: https://github.com/actions/setup-java#supported-distributions

--- a/.github/workflows/11-backend-integration.yml
+++ b/.github/workflows/11-backend-integration.yml
@@ -11,6 +11,10 @@ on:
     branches: [ main ]
     paths: [src/**, pom.xml, lombok.config]
 
+env:
+    # See: https://github.com/actions/setup-java#supported-distributions
+    JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,10 +23,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Run IT tests with maven
       run: INTEGRATION=true mvn -B test-compile failsafe:integration-test failsafe:verify

--- a/.github/workflows/11-backend-integration.yml
+++ b/.github/workflows/11-backend-integration.yml
@@ -6,10 +6,10 @@ name: "11-backend-integration: Java Integration tests"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/11-backend-integration.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/11-backend-integration.yml]
 
 env:
     # See: https://github.com/actions/setup-java#supported-distributions

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -6,10 +6,10 @@ name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/12-backend-jacoco.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/12-backend-jacoco.yml]
 
 env:
     # See: https://github.com/actions/setup-java#supported-distributions

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -11,6 +11,11 @@ on:
     branches: [ main ]
     paths: [src/**, pom.xml, lombok.config]
 
+env:
+    # See: https://github.com/actions/setup-java#supported-distributions
+    JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
+
 jobs:
   build-jacoco-report:
     runs-on: ubuntu-latest
@@ -19,10 +24,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Build with Maven
       env:

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -6,11 +6,11 @@ name: "13-backend-incremental-pitest: Java Mutation Testing (Pitest)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/13-backend-incremental-pitest.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
-
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/13-backend-incremental-pitest.yml]
+    
 env:
     # See: https://github.com/actions/setup-java#supported-distributions
     JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -11,6 +11,11 @@ on:
     branches: [ main ]
     paths: [src/**, pom.xml, lombok.config]
 
+env:
+    # See: https://github.com/actions/setup-java#supported-distributions
+    JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,10 +24,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
     - name: Figure out branch name
       id: get-branch-name
       run: | 

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -11,6 +11,11 @@ on:
     branches: [ main ]
     paths: [src/**, pom.xml, lombok.config]
 
+env:
+    # See: https://github.com/actions/setup-java#supported-distributions
+    JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,10 +36,12 @@ jobs:
           echo "branch_name=${BRANCH}"
           echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"    
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
     - name: Build with Maven
       run: mvn -B test 
     

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -6,10 +6,10 @@ name: "14-backend-pitest: Java Mutation Testing (Pitest)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/14-backend-pitest.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/14-backend-pitest.yml]
 
 env:
     # See: https://github.com/actions/setup-java#supported-distributions

--- a/.github/workflows/15-backend-format.yml
+++ b/.github/workflows/15-backend-format.yml
@@ -8,6 +8,10 @@ on:
     branches: [ main ]
     paths: [ src/** ]
 
+env:
+    # See: https://github.com/actions/setup-java#supported-distributions
+    JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -15,10 +19,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Java (version from .java-version file)
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+          distribution: ${{ env.JAVA_DISTRIBUTION }} 
           java-version-file: ./.java-version
+          cache: 'maven'
+          cache-dependency-path: 'pom.xml' 
 
       - name: Check formatting with Maven
         run: mvn git-code-format:validate-code-format

--- a/.github/workflows/15-backend-format.yml
+++ b/.github/workflows/15-backend-format.yml
@@ -3,10 +3,10 @@ name: "15-backend-format: Format Java Files"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [ src/** ]
+    paths: [ src/**, .github/workflows/15-backend-format.yml ]
   push:
     branches: [ main ]
-    paths: [ src/** ]
+    paths: [ src/** , .github/workflows/15-backend-format.yml]
 
 env:
     # See: https://github.com/actions/setup-java#supported-distributions

--- a/.github/workflows/40-check-production-build.yml
+++ b/.github/workflows/40-check-production-build.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+      # See: https://github.com/actions/setup-java#supported-distributions
+      JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
 jobs:
   build:
 
@@ -17,6 +21,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
+    - run: |
+        echo env.JAVA_DISTRIBUTION=${{ env.JAVA_DISTRIBUTION }}
     - uses: szenius/set-timezone@v2.0
       with:
         timezoneLinux: "America/Los_Angeles"
@@ -24,8 +30,10 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v3
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Build with Maven
       env:

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'src/**'
       - 'pom.xml'
+      - '.github/workflows/56-javadoc-main-branch.yml'
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -10,6 +10,9 @@ on:
 
 env:
   GH_TOKEN: ${{ github.token }}
+  # See: https://github.com/actions/setup-java#supported-distributions
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
+
 
 permissions:
   contents: write
@@ -24,10 +27,12 @@ jobs:
     - name: Checkout local code to establish repo
       uses: actions/checkout@v4
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
     paths:
       - 'src/**'
-      - 'pom.xml'    
+      - 'pom.xml'   
+      - '.github/workflows/58-javadoc-pr.yml' 
       
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -11,6 +11,8 @@ on:
       
 env:
   GH_TOKEN: ${{ github.token }}
+  # See: https://github.com/actions/setup-java#supported-distributions
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
 
 permissions:
   contents: write
@@ -71,8 +73,10 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v3
       with:
-         distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
   
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc


### PR DESCRIPTION
In this PR, we make several fixes to workflows that use `action/setup-java` to improve reliability and performance:
* Instead of hard-coding the value of `distribution`, we take it from a repo/org variable `JAVA_DISTRIBUTION` with a fallback value in case it is not defined.  This was motivated by a sudden outage in the distribution for `semeru` that caused all backend workflows to suddenly start failing across multiple projects for the course.   This way, if that happens again, we can change the distribution in one place instead of across dozens of files in dozens of repos.
* We add caching for the maven dependencies; we hope this improves running times


We also add a repeat to the deploy step that often fails because of contention over the gh-pages branch:

<img width="1056" alt="image" src="https://github.com/user-attachments/assets/043a4538-cfaa-4efa-99b1-66102a30e7fc">
