### PR TITLE
Remove stryker exception in SectionsOverTimeTable.test.js  by adding test

### DIFF
--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -41,7 +41,6 @@ export default function SectionsOverTimeTable({ sections }) {
       aggregate: getCourseId,
       Aggregated: ({ cell: { value } }) => `${value}`,
 
-      // Stryker disable next-line ArrowFunction: factor out and test the arrow function separately
       Cell: ({ cell: { value } }) => value.substring(0, value.length - 2),
     },
     {

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -309,4 +309,37 @@ describe("Section tests", () => {
         .querySelector('a[href$="/coursedetails/20221/12625"]'),
     ).toBeInTheDocument();
   });
+
+  test("Course ID's are correct", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+
+    );
+    const testId = "SectionsOverTimeTable";
+
+    const expandRow = screen.getByTestId(
+      `${testId}-cell-row-1-col-quarter-expand-symbols`,
+    );
+    fireEvent.click(expandRow);
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-3-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-4-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+  });
 });

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -317,7 +317,6 @@ describe("Section tests", () => {
           <SectionsOverTimeTable sections={fiveSections} />
         </MemoryRouter>
       </QueryClientProvider>,
-
     );
     const testId = "SectionsOverTimeTable";
 


### PR DESCRIPTION
In this PR, we added one test in SectionsOverTimeTable.test.js to remove a stryker exception.

This is work from @bsaiju from team f24-03.