### PR TITLE
pc - add sortField and sortDirection to /api/updates endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UpdateController.java
@@ -6,6 +6,8 @@ import edu.ucsb.cs156.courses.documents.Update;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Arrays;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -54,9 +56,43 @@ public class UpdateController extends ApiController {
               example = "5",
               required = true)
           @RequestParam
-          int pageSize) {
+          int pageSize,
+      @Parameter(
+              name = "sortField",
+              description = "sort field",
+              example = "subjectArea",
+              required = true)
+          @RequestParam
+          String sortField,
+      @Parameter(
+              name = "sortDirection",
+              description = "sort direction",
+              example = "ASC",
+              required = true)
+          @RequestParam
+          String sortDirection) {
     Iterable<Update> updates = null;
-    PageRequest pageRequest = PageRequest.of(page, pageSize, Direction.DESC, "lastUpdate");
+
+    List<String> allowedSortFields = Arrays.asList("subjectArea", "quarter", "lastUpdate");
+    if (!allowedSortFields.contains(sortField)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "%s is not a valid sort field.  Valid values are %s", sortField, allowedSortFields));
+    }
+    List<String> allowedSortDirections = Arrays.asList("ASC", "DESC");
+    if (!allowedSortDirections.contains(sortDirection)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "%s is not a valid sort direction.  Valid values are %s",
+              sortDirection, allowedSortDirections));
+    }
+
+    Direction sortDirectionObject = Direction.ASC;
+    if (sortDirection.equals("DESC")) {
+      sortDirectionObject = Direction.DESC;
+    }
+
+    PageRequest pageRequest = PageRequest.of(page, pageSize, sortDirectionObject, sortField);
 
     if (subjectArea.toUpperCase().equals("ALL") && quarter.toUpperCase().equals("ALL")) {
       updates = updateCollection.findAll(pageRequest);

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UpdateControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UpdateControllerTests.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import java.util.ArrayList;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -39,8 +40,13 @@ public class UpdateControllerTests extends ControllerTestCase {
   ArrayList<Update> emptyArray = new ArrayList<Update>();
   PageRequest pageRequest_0_10_DESC_lastUpdate =
       PageRequest.of(0, 10, Direction.DESC, "lastUpdate");
+  PageRequest pageRequest_0_10_ASC_subjectArea =
+      PageRequest.of(0, 10, Direction.ASC, "subjectArea");
+
   private final Page<Update> emptyPage_0_10_DESC_lastUpdate =
       new PageImpl<Update>(emptyArray, pageRequest_0_10_DESC_lastUpdate, 0);
+  private final Page<Update> emptyPage_0_10_ASC_subjectArea =
+      new PageImpl<Update>(emptyArray, pageRequest_0_10_ASC_subjectArea, 0);
 
   @Test
   @WithMockUser(roles = {"ADMIN"})
@@ -54,7 +60,9 @@ public class UpdateControllerTests extends ControllerTestCase {
     // act
     MvcResult response =
         mockMvc
-            .perform(get("/api/updates?subjectArea=ALL&quarter=ALL&page=0&pageSize=10"))
+            .perform(
+                get(
+                    "/api/updates?subjectArea=ALL&quarter=ALL&page=0&pageSize=10&sortField=lastUpdate&sortDirection=DESC"))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -76,7 +84,9 @@ public class UpdateControllerTests extends ControllerTestCase {
     // act
     MvcResult response =
         mockMvc
-            .perform(get("/api/updates?subjectArea=CMPSC&quarter=ALL&page=0&pageSize=10"))
+            .perform(
+                get(
+                    "/api/updates?subjectArea=CMPSC&quarter=ALL&page=0&pageSize=10&sortField=lastUpdate&sortDirection=DESC"))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -98,7 +108,9 @@ public class UpdateControllerTests extends ControllerTestCase {
     // act
     MvcResult response =
         mockMvc
-            .perform(get("/api/updates?subjectArea=ALL&quarter=20221&page=0&pageSize=10"))
+            .perform(
+                get(
+                    "/api/updates?subjectArea=ALL&quarter=20221&page=0&pageSize=10&sortField=lastUpdate&sortDirection=DESC"))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -115,18 +127,72 @@ public class UpdateControllerTests extends ControllerTestCase {
     // arrange
 
     when(updateCollection.findBySubjectAreaAndQuarter(
-            "CMPSC", "20221", pageRequest_0_10_DESC_lastUpdate))
-        .thenReturn(emptyPage_0_10_DESC_lastUpdate);
+            "CMPSC", "20221", pageRequest_0_10_ASC_subjectArea))
+        .thenReturn(emptyPage_0_10_ASC_subjectArea);
 
     // act
     MvcResult response =
         mockMvc
-            .perform(get("/api/updates?subjectArea=CMPSC&quarter=20221&page=0&pageSize=10"))
+            .perform(
+                get(
+                    "/api/updates?subjectArea=CMPSC&quarter=20221&page=0&pageSize=10&sortField=subjectArea&sortDirection=ASC"))
             .andExpect(status().isOk())
             .andReturn();
 
     // assert
-    String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_DESC_lastUpdate);
+    String expectedResponseAsJson = objectMapper.writeValueAsString(emptyPage_0_10_ASC_subjectArea);
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponseAsJson, actualResponse);
+  }
+
+  @Test
+  @WithMockUser(roles = {"ADMIN"})
+  public void when_sortField_is_invalid_throws_exception() throws Exception {
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                get(
+                    "/api/updates?subjectArea=CMPSC&quarter=20221&page=0&pageSize=10&sortField=invalid&sortDirection=DESC"))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    // assert
+    Map<String, String> expectedResponse =
+        Map.of(
+            "message",
+            "invalid is not a valid sort field.  Valid values are [subjectArea, quarter, lastUpdate]",
+            "type",
+            "IllegalArgumentException");
+
+    String expectedResponseAsJson = objectMapper.writeValueAsString(expectedResponse);
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponseAsJson, actualResponse);
+  }
+
+  @Test
+  @WithMockUser(roles = {"ADMIN"})
+  public void when_sortDirection_is_invalid_throws_exception() throws Exception {
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                get(
+                    "/api/updates?subjectArea=CMPSC&quarter=20221&page=0&pageSize=10&sortField=subjectArea&sortDirection=INVALID"))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    // assert
+    Map<String, String> expectedResponse =
+        Map.of(
+            "message",
+            "INVALID is not a valid sort direction.  Valid values are [ASC, DESC]",
+            "type",
+            "IllegalArgumentException");
+
+    String expectedResponseAsJson = objectMapper.writeValueAsString(expectedResponse);
     String actualResponse = response.getResponse().getContentAsString();
     assertEquals(expectedResponseAsJson, actualResponse);
   }


### PR DESCRIPTION
In this PR we add add sortField and sortDirection to updates endpoint to the /api/updates endpoint.   

This will make support a variety of use cases for admins (including seeing large numbers of updates not only by subjectArea and quarter, but also by lastUpdated time.

For example, sorting DESC by lastUpdated will show the updates that are happening in real time on the first page.

# Before

<img width="799" alt="image" src="https://github.com/user-attachments/assets/66992b72-aaa1-42e5-8394-f4008d696b6f" />

# After

<img width="691" alt="image" src="https://github.com/user-attachments/assets/4b832275-7895-44e0-84b6-b9b9c6434c54" />

# To test

To ensure that there are updates to check, you'll first need to run one of the jobs that updates courses, for example:

<img width="430" alt="image" src="https://github.com/user-attachments/assets/7e1846bf-15cb-4b66-bed0-3f5a96a1eddc" />

Then, use values such as those suggested on the Swagger page for /api/updates

You may also want to try invalid values for sortField and sortDirection; you should see error messages such as these:

<img width="719" alt="image" src="https://github.com/user-attachments/assets/337d65d8-964a-4fd6-b573-6c5b9f6990fc" />

<img width="631" alt="image" src="https://github.com/user-attachments/assets/44f64585-af79-401f-84f1-0cedbdead40c" />

Check that the updates returned are sorted in the correct direction (ASC for ascending and DESC for descending), by either subjectArea, quarter, or lastUpdate.
