### PR TITLE
pc - add GenericDropdown component

### DIFF
--- a/frontend/src/main/components/Utils/GenericDropdown.js
+++ b/frontend/src/main/components/Utils/GenericDropdown.js
@@ -1,12 +1,8 @@
-import { useState } from "react";
+import useLocalStorage from "main/utils/useLocalStorage";
 import { Form } from "react-bootstrap";
 
 const GenericDropdown = ({ values, setValue, controlId, label }) => {
-  const localStorageValue = localStorage.getItem(controlId);
-  const [valueState, setValueState] = useState(
-    // Stryker disable next-line all : not sure how to test/mock local storage
-    localStorageValue || values[0],
-  );
+  const [valueState, setValueState] = useLocalStorage(controlId, values[0]);
 
   const handleUpdateFieldChange = (event) => {
     localStorage.setItem(controlId, event.target.value);

--- a/frontend/src/main/components/Utils/GenericDropdown.js
+++ b/frontend/src/main/components/Utils/GenericDropdown.js
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Form } from "react-bootstrap";
+
+const GenericDropdown = ({ values, setValue, controlId, label }) => {
+  const localStorageValue = localStorage.getItem(controlId);
+  const [valueState, setValueState] = useState(
+    // Stryker disable next-line all : not sure how to test/mock local storage
+    localStorageValue || values[0],
+  );
+
+  const handleUpdateFieldChange = (event) => {
+    localStorage.setItem(controlId, event.target.value);
+    setValueState(event.target.value);
+    setValue(event.target.value);
+  };
+
+  return (
+    <Form.Group controlId={controlId}>
+      <Form.Label>{label}</Form.Label>
+      <Form.Control
+        as="select"
+        value={valueState}
+        onChange={handleUpdateFieldChange}
+      >
+        {values.map(function (v, i) {
+          const key = `${controlId}-option-${i}`;
+          return (
+            <option key={key} data-testid={key} value={v}>
+              {v}
+            </option>
+          );
+        })}
+      </Form.Control>
+    </Form.Group>
+  );
+};
+
+export default GenericDropdown;

--- a/frontend/src/stories/components/Utils/GenericDropdown.stories.js
+++ b/frontend/src/stories/components/Utils/GenericDropdown.stories.js
@@ -1,0 +1,28 @@
+import React from "react";
+
+import GenericDropdown from "main/components/Utils/GenericDropdown";
+
+export default {
+  title: "components/Utils/GenericDropdown",
+  component: GenericDropdown,
+};
+
+const Template = (args) => {
+  return <GenericDropdown {...args} />;
+};
+
+export const PizzaToppings = Template.bind({});
+PizzaToppings.args = {
+  values: ["Cheese", "Mushroom", "Pepperoni"],
+  setValue: (v) => console.log(`value: ${v}`),
+  controlId: "PizzaToppings",
+  label: "Pizza Toppings",
+};
+
+export const Sodas = Template.bind({});
+Sodas.args = {
+  values: ["Coke", "Pepsi", "Dr. Pepper"],
+  setValue: (v) => console.log(`value: ${v}`),
+  controlId: "Sodas",
+  label: "Sodas",
+};

--- a/frontend/src/tests/components/Utils/GenericDropdown.test.js
+++ b/frontend/src/tests/components/Utils/GenericDropdown.test.js
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import GenericDropdown from "main/components/Utils/GenericDropdown";
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useState: jest.fn(),
+}));
+
+describe("GenericDropdown tests", () => {
+  beforeEach(() => {
+    useState.mockImplementation(jest.requireActual("react").useState);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const setPizzaTopping = jest.fn();
+
+  test("when I select an object, the value changes", async () => {
+    render(
+      <GenericDropdown
+        values={["Cheese", "Mushroom", "Pepperoni"]}
+        setValue={setPizzaTopping}
+        controlId="pizza"
+        label="Select Pizza Topping"
+      />,
+    );
+    expect(
+      await screen.findByLabelText("Select Pizza Topping"),
+    ).toBeInTheDocument();
+    const selectTopping = screen.getByLabelText("Select Pizza Topping");
+    userEvent.selectOptions(selectTopping, "Mushroom");
+    expect(setPizzaTopping).toHaveBeenCalledWith("Mushroom");
+  });
+
+  test("when localstorage has a value, it is passed to useState", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => "Pepperoni");
+
+    const setQuarterStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setQuarterStateSpy]);
+
+    render(
+      <GenericDropdown
+        values={["Cheese", "Mushroom", "Pepperoni"]}
+        setValue={setPizzaTopping}
+        controlId="pizza"
+        label="Select Pizza Topping"
+      />,
+    );
+
+    await screen.findByTestId("pizza-option-0");
+    expect(screen.getByTestId("pizza-option-1")).toBeInTheDocument();
+    expect(screen.getByTestId("pizza-option-2")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This is a generic dropdown used for both the list of sortFields and sortDirections on the UpdatesSearchForm

# Details

The AdminUpdatesPage is currently a placeholder, but we want to add a control panel that allows an admin to view the Updates collection in the MongoDB database in a variety of ways, including: 

* By subjectArea, or ALL subjectAreas
* By quarter, or ALL quarters
* Specifying a sort field from among (subjectArea, quarter, lastUpdate)
* Specifying a sort direction from among (ASC, DESC)
* Specifying a page size from among (10, 50, 100, 200, 500).

Selectors (dropdown components) already exist for the first two, but not for the latter three.  The GenericDropdown covers these three use cases.

For the storybook, though, we use fictional lists of pizza toppings and beverages to signal that this is really a generic component that can be used for any kind of list of values.

# Storybook

* [Pizza Toppings](https://66d38213c4af0f3da7d52f03-mvbmizhbgt.chromatic.com/?path=/story/components-utils-genericdropdown--pizza-toppings)
* [Sodas](https://66d38213c4af0f3da7d52f03-mvbmizhbgt.chromatic.com/?path=/story/components-utils-genericdropdown--sodas)

# Screenshot

![genericDropdown](https://github.com/user-attachments/assets/d520df57-bf65-476f-9d8b-faadd2e78f1a)
