### PR TITLE
pc - add OurPagination component

### DIFF
--- a/frontend/src/main/components/Utils/OurPagination.js
+++ b/frontend/src/main/components/Utils/OurPagination.js
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { Pagination } from "react-bootstrap";
+
+export const emptyArray = () => []; // factored out for Stryker testing
+
+const OurPagination = ({
+  updateActivePage,
+  totalPages = 10,
+  maxPages = 8,
+  testId = "OurPagination",
+}) => {
+  const [activePage, setActivePage] = useState(1);
+  const nextPage = () => {
+    const newPage = Math.min(activePage + 1, totalPages);
+    setActivePage(newPage);
+    updateActivePage(newPage);
+  };
+  const prevPage = () => {
+    const newPage = Math.max(activePage - 1, 1);
+    setActivePage(newPage);
+    updateActivePage(newPage);
+  };
+  const thisPage = (page) => {
+    setActivePage(page);
+    updateActivePage(page);
+  };
+
+  const pageButton = (number) => (
+    <Pagination.Item
+      key={number}
+      active={number === activePage}
+      onClick={() => thisPage(number)}
+      data-testid={`${testId}-${number}`}
+    >
+      {number}
+    </Pagination.Item>
+  );
+
+  const generateSimplePaginationItems = () => {
+    const paginationItems = emptyArray();
+    for (let number = 1; number <= totalPages; number++) {
+      paginationItems.push(pageButton(number));
+    }
+    return paginationItems;
+  };
+
+  const generatePaginationItemsWithEllipsis = () => {
+    const paginationItems = emptyArray();
+
+    const leftEllipsis = activePage > 3;
+    const rightEllipsis = activePage < totalPages - 2;
+
+    paginationItems.push(pageButton(1));
+    if (leftEllipsis) {
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="left-ellipsis"
+          data-testid={`${testId}-left-ellipsis`}
+        />,
+      );
+    }
+    // Show a range of pages around the active page
+    let start = Math.max(activePage - 1, 2);
+    let end = Math.min(activePage + 1, totalPages - 1);
+
+    for (let number = start; number <= end; number++) {
+      paginationItems.push(pageButton(number));
+    }
+
+    if (rightEllipsis) {
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="right-ellipsis"
+          data-testid={`${testId}-right-ellipsis`}
+        />,
+      );
+    }
+    paginationItems.push(pageButton(totalPages));
+
+    return paginationItems;
+  };
+
+  const generatePaginationItems = () =>
+    totalPages <= maxPages
+      ? generateSimplePaginationItems()
+      : generatePaginationItemsWithEllipsis();
+
+  return (
+    <Pagination>
+      <Pagination.Prev onClick={prevPage} data-testid={`${testId}-prev`} />
+      {generatePaginationItems()}
+      <Pagination.Next onClick={nextPage} data-testid={`${testId}-next`} />
+    </Pagination>
+  );
+};
+
+export default OurPagination;

--- a/frontend/src/stories/components/Utils/OurPagination.stories.js
+++ b/frontend/src/stories/components/Utils/OurPagination.stories.js
@@ -1,0 +1,28 @@
+import OurPagination from "main/components/Utils/OurPagination";
+
+export default {
+  title: "components/Utils/OurPagination",
+  component: OurPagination,
+};
+
+const Template = (args) => {
+  return <OurPagination {...args} />;
+};
+
+export const Total_10_Max_5 = Template.bind({});
+Total_10_Max_5.args = {
+  totalPages: 10,
+  maxPages: 5,
+  updateActivePage: (p) => {
+    console.log(`Now on page ${p}`);
+  },
+};
+
+export const Total_5_Max_10 = Template.bind({});
+Total_5_Max_10.args = {
+  totalPages: 5,
+  maxPages: 10,
+  updateActivePage: (p) => {
+    console.log(`Now on page ${p}`);
+  },
+};

--- a/frontend/src/tests/components/Utils/OurPagination.test.js
+++ b/frontend/src/tests/components/Utils/OurPagination.test.js
@@ -1,0 +1,246 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import OurPagination, { emptyArray } from "main/components/Utils/OurPagination";
+
+const checkTestIdsInOrder = (testIds) => {
+  const links = screen.getAllByTestId(/OurPagination-/);
+  expect(links.length).toBe(testIds.length);
+
+  for (var i = 0; i < links.length; i++) {
+    expect(screen.getByTestId(testIds[i])).toBe(links[i]);
+  }
+};
+
+describe("OurPagination tests", () => {
+  test("emptyArray returns empty array", () => {
+    expect(emptyArray()).toStrictEqual([]);
+  });
+
+  test("renders the correct text for totalPages 5 maxPages 10", async () => {
+    // Arrange
+
+    const updateActivePage = jest.fn();
+
+    // Act
+    render(
+      <OurPagination
+        totalPages={5}
+        maxPages={10}
+        updateActivePage={updateActivePage}
+      />,
+    );
+
+    // Assert
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders the correct text for totalPages 10 maxPages 10", async () => {
+    // Arrange
+
+    const updateActivePage = jest.fn();
+
+    // Act
+    render(<OurPagination maxPages={10} updateActivePage={updateActivePage} />);
+
+    // Assert
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-7",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-10",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders the correct text for totalPages 12 maxPages 5", async () => {
+    // Arrange
+
+    const updateActivePage = jest.fn();
+
+    // Act
+    render(
+      <OurPagination
+        totalPages={12}
+        maxPages={5}
+        updateActivePage={updateActivePage}
+      />,
+    );
+
+    // Assert
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    const nextButton = screen.getByTestId("OurPagination-next");
+    fireEvent.click(nextButton);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    fireEvent.click(nextButton);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    fireEvent.click(nextButton);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    const prevButton = screen.getByTestId("OurPagination-prev");
+    fireEvent.click(prevButton);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    const button1 = screen.getByTestId("OurPagination-1");
+    fireEvent.click(button1);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    const button12 = screen.getByTestId("OurPagination-12");
+    fireEvent.click(button12);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-11",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+
+    fireEvent.click(prevButton);
+    fireEvent.click(prevButton);
+    fireEvent.click(prevButton);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-10",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders the correct text for totalPages 5 maxPages 2", async () => {
+    // Arrange
+
+    const updateActivePage = jest.fn();
+
+    // Act
+    render(
+      <OurPagination
+        totalPages={5}
+        maxPages={3}
+        updateActivePage={updateActivePage}
+      />,
+    );
+
+    // Assert
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-right-ellipsis",
+      "OurPagination-5",
+      "OurPagination-next",
+    ]);
+
+    const button1 = screen.getByTestId("OurPagination-1");
+    expect(button1.parentElement).toHaveClass("active");
+    const button2 = screen.getByTestId("OurPagination-2");
+    expect(button2.parentElement).not.toHaveClass("active");
+
+    const nextButton = screen.getByTestId("OurPagination-next");
+    fireEvent.click(nextButton);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-right-ellipsis",
+      "OurPagination-5",
+      "OurPagination-next",
+    ]);
+
+    fireEvent.click(nextButton);
+
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-next",
+    ]);
+
+    fireEvent.click(nextButton);
+  });
+});


### PR DESCRIPTION
This is a wrapper around the functionality of the React Bootstrap Pagination component to add the callback functions and tests needed to use it in practice

This is being added to support pagination for the future AdminUpdatesPage

# Details

React Bootstrap has a pagination component documented [here](https://react-bootstrap.netlify.app/docs/components/pagination/).   It has components from which pagination can be constructed, but the callback functions and code to choose which components to display is left as an exercise to the programmer.

This component completes that exercise by creating a component that can be dropped in to paginate a table.

# Storybook

* [total-10-max-5](https://66d38213c4af0f3da7d52f03-qqvdkenrxe.chromatic.com/?path=/story/components-utils-ourpagination--total-10-max-5)
* (total-5-max-10)[https://66d38213c4af0f3da7d52f03-qqvdkenrxe.chromatic.com/?path=/story/components-utils-ourpagination--total-5-max-10]

# Screenshots

![ourPagination](https://github.com/user-attachments/assets/abb3ca54-cd24-4074-9a41-48314ce684f8)

