### PR TITLE
pc - cleanup warnings about keys being spread in props

### DIFF
--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -33,11 +33,13 @@ export default function OurTable({
       <thead>
         {headerGroups.map((headerGroup, i) => (
           <tr
+            // Stryker disable next-line all: can't test keys since they are internal to React
             key={`row-${i}`}
             {...removeKey(headerGroup.getHeaderGroupProps())}
           >
             {headerGroup.headers.map((column) => (
               <th
+                // Stryker disable next-line all: can't test keys since they are internal to React
                 key={column.id}
                 {...removeKey(
                   column.getHeaderProps(column.getSortByToggleProps()),
@@ -57,10 +59,15 @@ export default function OurTable({
         {rows.map((row, i) => {
           prepareRow(row);
           return (
-            <tr key={`row-${i}`} {...removeKey(row.getRowProps())}>
+            <tr
+              // Stryker disable next-line all: can't test keys since they are internal to React
+              key={`row-${i}`}
+              {...removeKey(row.getRowProps())}
+            >
               {row.cells.map((cell, _index) => {
                 return (
                   <td
+                    // Stryker disable next-line all: can't test keys since they are internal to React
                     key={cell.column.id}
                     {...removeKey(cell.getCellProps())}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useSortBy, useTable } from "react-table";
 import { Button, Table } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
+import { removeKey } from "main/utils/removeKey";
 
 export default function OurTable({
   columns,
@@ -30,11 +31,17 @@ export default function OurTable({
   return (
     <Table {...getTableProps()} striped bordered hover>
       <thead>
-        {headerGroups.map((headerGroup) => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
+        {headerGroups.map((headerGroup, i) => (
+          <tr
+            key={`row-${i}`}
+            {...removeKey(headerGroup.getHeaderGroupProps())}
+          >
             {headerGroup.headers.map((column) => (
               <th
-                {...column.getHeaderProps(column.getSortByToggleProps())}
+                key={column.id}
+                {...removeKey(
+                  column.getHeaderProps(column.getSortByToggleProps()),
+                )}
                 data-testid={`${testid}-header-${column.id}`}
               >
                 {column.render("Header")}
@@ -47,14 +54,15 @@ export default function OurTable({
         ))}
       </thead>
       <tbody {...getTableBodyProps()}>
-        {rows.map((row) => {
+        {rows.map((row, i) => {
           prepareRow(row);
           return (
-            <tr {...row.getRowProps()}>
+            <tr key={`row-${i}`} {...removeKey(row.getRowProps())}>
               {row.cells.map((cell, _index) => {
                 return (
                   <td
-                    {...cell.getCellProps()}
+                    key={cell.column.id}
+                    {...removeKey(cell.getCellProps())}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                   >
                     {cell.render("Cell")}

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from "react";
 import { useTable, useGroupBy, useExpanded } from "react-table";
 import { Table } from "react-bootstrap";
+import { removeKey } from "main/utils/removeKey";
 
 // Stryker disable StringLiteral, ArrayDeclaration
 export default function SectionsTableBase({
@@ -26,11 +27,12 @@ export default function SectionsTableBase({
   return (
     <Table {...getTableProps()} bordered hover className="table-hover">
       <thead key="thead">
-        {headerGroups.map((headerGroup) => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
+        {headerGroups.map((headerGroup, i) => (
+          <tr key={`tr-${i}`} {...removeKey(headerGroup.getHeaderGroupProps())}>
             {headerGroup.headers.map((column) => (
               <th
-                {...column.getHeaderProps()}
+                key={`${column.id}`}
+                {...removeKey(column.getHeaderProps())}
                 data-testid={`${testid}-header-${column.id}`}
               >
                 {column.render("Header")}
@@ -49,11 +51,12 @@ export default function SectionsTableBase({
             <Fragment key={`row-${i}`}>
               {row.cells[0].isGrouped ||
               (!row.cells[0].isGrouped && row.allCells[3].value) ? (
-                <tr style={rowStyle}>
+                <tr style={rowStyle} key={`row-${i}`}>
                   {row.cells.map((cell, _index) => {
                     return (
                       <td
-                        {...cell.getCellProps()}
+                        key={`${cell.column.id}`}
+                        {...removeKey(cell.getCellProps())}
                         data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                         // Stryker disable next-line ObjectLiteral
                         style={{

--- a/frontend/src/main/utils/removeKey.js
+++ b/frontend/src/main/utils/removeKey.js
@@ -1,0 +1,4 @@
+export const removeKey = (obj) => {
+  const { key, ...rest } = obj;
+  return rest;
+};

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -48,6 +48,9 @@ describe("OurTable tests", () => {
 
   test("renders a table with two rows without crashing", () => {
     render(<OurTable columns={columns} data={threeRows} />);
+    expect(screen.getByTestId("testid-cell-row-0-col-Log")).toHaveTextContent(
+      "foobar baz",
+    );
   });
 
   test("The button appears in the table", async () => {

--- a/frontend/src/tests/utils/removeKey.test.js
+++ b/frontend/src/tests/utils/removeKey.test.js
@@ -1,0 +1,7 @@
+import { removeKey } from "main/utils/removeKey";
+describe("removeKey tests", () => {
+  test("it returns the object with key property removed", () => {
+    const obj = { key: "k", foo: "f", bar: "b" };
+    expect(removeKey(obj)).toEqual({ foo: "f", bar: "b" });
+  });
+});


### PR DESCRIPTION
Prior to this PR, the frontend tests contained many warnings of the form:
```
 Warning: A props object containing a "key" prop is being spread into JSX:
```

This PR removes those warnings by adding a utility function to remove the key object from the properties that are being spread in the various table components, and then manually adding an appropriate key (since it is mandatory to have a key property in lists of children.)

# Details

Here's an example of the warnings that this PR removes:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/ed56cdae-6857-4de4-ab81-7e18abbaf4f1" />

