### PR TITLE
pc - filter out weird subjectArea records

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBSubjectsService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBSubjectsService.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.courses.entities.UCSBSubject;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -53,7 +54,8 @@ public class UCSBSubjectsService {
     List<UCSBSubject> subjects =
         mapper.readValue(retBody, new TypeReference<List<UCSBSubject>>() {});
 
-    return subjects;
+    Stream<UCSBSubject> subjectStream = subjects.stream();
+    return subjectStream.filter(us -> !us.getSubjectCode().equals("SUBJECTCODE")).toList();
   }
 
   public List<UCSBSubject> loadAllSubjects() throws JsonProcessingException {

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBSubjectsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBSubjectsServiceTests.java
@@ -1,6 +1,6 @@
 package edu.ucsb.cs156.courses.services;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -30,38 +30,46 @@ class UCSBSubjectsServiceTests {
   @Value("${app.ucsb.api.consumer_key}")
   private String apiKey;
 
-  private static final String SUBJECTCODE = "SUBJECTCODE";
-  private static final String SUBJECTTRANSLATION = "SUBJECTTRANSLATION";
-  private static final String DEPTCODE = "DEPTCODE";
-  private static final String COLLEGECODE = "COLLEGECODE";
-  private static final String RELATEDDEPTCODE = "RELATEDDEPTCODE";
+  private static final String SUBJECTCODE = "ANTH";
+  private static final String SUBJECTTRANSLATION = "Anthropology";
+  private static final String DEPTCODE = "ANTH";
+  private static final String COLLEGECODE = "L&S";
+  private static final String RELATEDDEPTCODE = "NONE";
   private static final Boolean INACTIVE = false;
 
-  @Test
-  void get_returns_a_list_of_subjects() throws Exception {
-
-    String expectedURL = UCSBSubjectsService.ENDPOINT;
-
-    String expectedResult =
-        String.format(
-            """
-            [
+  private String expectedResult =
+      String.format(
+          """
+          [
             {
               \"subjectCode\": \"%s\",
               \"subjectTranslation\":\"%s\",
               \"deptCode\": \"%s\",
               \"collegeCode\": \"%s\",
               \"relatedDeptCode\": \"%s\",
-              \"inactive\": \"%s\"
+              \"inactive\": %s
+            },
+            {
+              \"subjectCode\": \"SUBJECTCODE\",
+              \"subjectTranslation\":\"SUBJECTTRANSLATION\",
+              \"deptCode\": \"DEPTCODE\",
+              \"collegeCode\": \"COLLEGECODE\",
+              \"relatedDeptCode\": \"RELATEDDEPTCODE\",
+              \"inactive\": false
             }
-            ]
-            """,
-            SUBJECTCODE,
-            SUBJECTTRANSLATION,
-            DEPTCODE,
-            COLLEGECODE,
-            RELATEDDEPTCODE,
-            INACTIVE.toString());
+          ]
+          """,
+          SUBJECTCODE,
+          SUBJECTTRANSLATION,
+          DEPTCODE,
+          COLLEGECODE,
+          RELATEDDEPTCODE,
+          INACTIVE.toString());
+
+  @Test
+  void get_returns_a_list_of_subjects() throws Exception {
+
+    String expectedURL = UCSBSubjectsService.ENDPOINT;
 
     UCSBSubject expectedSubject =
         UCSBSubject.builder()
@@ -83,34 +91,13 @@ class UCSBSubjectsServiceTests {
     List<UCSBSubject> actualResult = ucsbSubjectsService.get();
     List<UCSBSubject> expectedList = new ArrayList<>();
     expectedList.addAll(Arrays.asList(expectedSubject));
-    assertEquals(expectedList, actualResult);
+    assertIterableEquals(expectedList, actualResult);
   }
 
   @Test
   void test_loadAllSubjects() throws Exception {
 
     String expectedURL = UCSBSubjectsService.ENDPOINT;
-
-    String expectedResult =
-        String.format(
-            """
-                [
-                  {
-                    \"subjectCode\": \"%s\",
-                    \"subjectTranslation\":\"%s\",
-                    \"deptCode\": \"%s\",
-                    \"collegeCode\": \"%s\",
-                    \"relatedDeptCode\": \"%s\",
-                    \"inactive\": \"%s\"
-                  }
-                ]
-            """,
-            SUBJECTCODE,
-            SUBJECTTRANSLATION,
-            DEPTCODE,
-            COLLEGECODE,
-            RELATEDDEPTCODE,
-            INACTIVE.toString());
 
     UCSBSubject expectedSubject =
         UCSBSubject.builder()
@@ -132,6 +119,6 @@ class UCSBSubjectsServiceTests {
     List<UCSBSubject> actualResult = ucsbSubjectsService.loadAllSubjects();
     List<UCSBSubject> expectedList = new ArrayList<>();
     expectedList.addAll(Arrays.asList(expectedSubject));
-    assertEquals(expectedList, actualResult);
+    assertIterableEquals(expectedList, actualResult);
   }
 }


### PR DESCRIPTION
Sometimes we end up with weird records in the subjectArea table that have field values that are identical to the field names.  We are not sure if this is a fault of the API, or a consequence of some other bug.  It hasn't happened in a while, so it may have been a transient bug in the UCSB Developer API, and this PR may no longer be neeeded.

But we'll leave this here as a draft PR for now in case it arises again.

