### PR TITLE
pc - add a new method for getting the quarters that are in active registration passes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgument>-proc:full</compilerArgument>
-                </configuration>
-            </plugin>
             <!-- Test case coverage report -->
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/main/java/edu/ucsb/cs156/courses/entities/UCSBAPIQuarter.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/UCSBAPIQuarter.java
@@ -14,27 +14,27 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity(name = "ucsbapiquarter")
 public class UCSBAPIQuarter {
-  @Id private String quarter; // example: 20243
-  private String qyy; // example: M24
-  private String name; // example: SUMMER 2024
-  private String category; // example: SUMMER
-  private String academicYear; // example: 2023-2024
-  private LocalDateTime firstDayOfClasses; // example: 2024-06-24T00:00:00
-  private LocalDateTime lastDayOfClasses; // example: 2024-09-13T00:00:00
-  private LocalDateTime firstDayOfFinals; // example: 2024-09-14T00:00:00
-  private LocalDateTime lastDayOfFinals; // example: 2024-09-14T00:00:00
-  private LocalDateTime firstDayOfQuarter; // example: 2024-06-24T00:00:00
-  private LocalDateTime lastDayOfSchedule; // example: 2024-09-21T00:00:00
-  private LocalDateTime pass1Begin; // example: 2024-04-08T09:00:00
-  private LocalDateTime pass2Begin; // example: 2024-04-22T09:00:00
-  private LocalDateTime pass3Begin; // example: 2024-05-06T09:00:00
-  private LocalDateTime feeDeadline; // example: 2024-06-26T00:00:00
-  private LocalDateTime lastDayToAddUnderGrad; // example: 2024-07-15T00:00:00
-  private LocalDateTime lastDayToAddGrad; // example: 2024-09-13T00:00:00
-  private LocalDateTime lastDayThirdWeek; // example: null
+    @Id
+    private String quarter; // example: 20243
+    private String qyy; // example: M24
+    private String name; // example: SUMMER 2024
+    private String category; // example: SUMMER
+    private String academicYear; // example: 2023-2024
+    private LocalDateTime firstDayOfClasses; // example: 2024-06-24T00:00:00
+    private LocalDateTime lastDayOfClasses; // example: 2024-09-13T00:00:00
+    private LocalDateTime firstDayOfFinals; // example: 2024-09-14T00:00:00
+    private LocalDateTime lastDayOfFinals; // example: 2024-09-14T00:00:00
+    private LocalDateTime firstDayOfQuarter; // example: 2024-06-24T00:00:00
+    private LocalDateTime lastDayOfSchedule; // example: 2024-09-21T00:00:00
+    private LocalDateTime pass1Begin; // example: 2024-04-08T09:00:00
+    private LocalDateTime pass2Begin; // example: 2024-04-22T09:00:00
+    private LocalDateTime pass3Begin; // example: 2024-05-06T09:00:00
+    private LocalDateTime feeDeadline; // example: 2024-06-26T00:00:00
+    private LocalDateTime lastDayToAddUnderGrad; // example: 2024-07-15T00:00:00
+    private LocalDateTime lastDayToAddGrad; // example: 2024-09-13T00:00:00
+    private LocalDateTime lastDayThirdWeek; // example: null
 
-  public static final String SAMPLE_QUARTER_JSON_M24 =
-      """
+    public static final String SAMPLE_QUARTER_JSON_M24 = """
                 {
                     "quarter": "20243",
                     "qyy": "M24",
@@ -57,8 +57,7 @@ public class UCSBAPIQuarter {
                 }
             """;
 
-  public static final String SAMPLE_QUARTER_JSON_F20 =
-      """
+    public static final String SAMPLE_QUARTER_JSON_F20 = """
                     {
                         "quarter": "20204",
                         "qyy": "F20",
@@ -81,8 +80,7 @@ public class UCSBAPIQuarter {
                     }
             """;
 
-  public static final String SAMPLE_QUARTER_JSON_W21 =
-      """
+    public static final String SAMPLE_QUARTER_JSON_W21 = """
                     {
                         "quarter": "20211",
                         "qyy": "W21",
@@ -104,4 +102,142 @@ public class UCSBAPIQuarter {
                         "lastDayThirdWeek": "2021-01-26T00:00:00"
                     },
             """;
+
+    public static final String SAMPLE_QUARTER_JSON_S21 = """
+                    {
+                        "quarter": "20212",
+                        "qyy": "S21",
+                        "name": "SPRING 2021",
+                        "category": "SPRING",
+                        "academicYear": "2020-2021",
+                        "firstDayOfClasses": "2021-03-29T00:00:00",
+                        "lastDayOfClasses": "2021-06-11T00:00:00",
+                        "firstDayOfFinals": "2021-06-12T00:00:00",
+                        "lastDayOfFinals": "2021-06-18T00:00:00",
+                        "firstDayOfQuarter": "2021-03-29T00:00:00",
+                        "lastDayOfSchedule": "2021-06-26T00:00:00",
+                        "pass1Begin": "2020-12-28T09:00:00",
+                        "pass2Begin": "2021-01-11T09:00:00",
+                        "pass3Begin": "2021-01-25T09:00:00",
+                        "feeDeadline": "2021-03-15T00:00:00",
+                        "lastDayToAddUnderGrad": "2021-04-19T00:00:00",
+                        "lastDayToAddGrad": "2021-04-19T00:00:00",
+                        "lastDayThirdWeek": "2021-04-20T00:00:00"
+                    }
+            """;
+
+    public static final String SAMPLE_QUARTER_JSON_M21 = """
+                    {
+                        "quarter": "20213",
+                        "qyy": "M21",
+                        "name": "SUMMER 2021",
+                        "category": "SUMMER",
+                        "academicYear": "2020-2021",
+                        "firstDayOfClasses": "2021-06-28T00:00:00",
+                        "lastDayOfClasses": "2021-09-10T00:00:00",
+                        "firstDayOfFinals": "2021-09-11T00:00:00",
+                        "lastDayOfFinals": "2021-09-17T00:00:00",
+                        "firstDayOfQuarter": "2021-06-28T00:00:00",
+                        "lastDayOfSchedule": "2021-09-18T00:00:00",
+                        "pass1Begin": "2021-02-08T09:00:00",
+                        "pass2Begin": "2021-02-22T09:00:00",
+                        "pass3Begin": "2021-03-08T09:00:00",
+                        "feeDeadline": "2021-06-15T00:00:00",
+                        "lastDayToAddUnderGrad": "2021-07-12T00:00:00",
+                        "lastDayToAddGrad": "2021-07-12T00:00:00",
+                        "lastDayThirdWeek": "2021-07-13T00:00:00"
+                    }
+            """;
+
+    public static final String SAMPLE_QUARTER_JSON_F21 = """
+                    {
+                        "quarter": "20214",
+                        "qyy": "F21",
+                        "name": "FALL 2021",
+                        "category": "FALL",
+                        "academicYear": "2021-2022",
+                        "firstDayOfClasses": "2021-10-01T00:00:00",
+                        "lastDayOfClasses": "2021-12-10T00:00:00",
+                        "firstDayOfFinals": "2021-12-11T00:00:00",
+                        "lastDayOfFinals": "2021-12-17T00:00:00",
+                        "firstDayOfQuarter": "2021-09-26T00:00:00",
+                        "lastDayOfSchedule": "2022-01-01T00:00:00",
+                        "pass1Begin": "2021-05-10T09:00:00",
+                        "pass2Begin": "2021-05-24T09:00:00",
+                        "pass3Begin": "2021-06-07T09:00:00",
+                        "feeDeadline": "2021-09-13T00:00:00",
+                        "lastDayToAddUnderGrad": "2021-10-18T00:00:00",
+                        "lastDayToAddGrad": "2021-10-18T00:00:00",
+                        "lastDayThirdWeek": "2021-10-19T00:00:00"
+                    }
+            """;
+    public static final String SAMPLE_QUARTER_JSON_W22 = """
+                    {
+                        "quarter": "20221",
+                        "qyy": "W22",
+                        "name": "WINTER 2022",
+                        "category": "WINTER",
+                        "academicYear": "2021-2022",
+                        "firstDayOfClasses": "2022-01-03T00:00:00",
+                        "lastDayOfClasses": "2022-03-11T00:00:00",
+                        "firstDayOfFinals": "2022-03-12T00:00:00",
+                        "lastDayOfFinals": "2022-03-18T00:00:00",
+                        "firstDayOfQuarter": "2022-01-03T00:00:00",
+                        "lastDayOfSchedule": "2022-03-26T00:00:00",
+                        "pass1Begin": "2021-11-08T09:00:00",
+                        "pass2Begin": "2021-11-29T09:00:00",
+                        "pass3Begin": "2021-12-13T09:00:00",
+                        "feeDeadline": "2021-12-14T00:00:00",
+                        "lastDayToAddUnderGrad": "2022-01-24T00:00:00",
+                        "lastDayToAddGrad": "2022-01-24T00:00:00",
+                        "lastDayThirdWeek": "2022-01-25T00:00:00"
+                    }
+            """;
+
+    public static final String SAMPLE_QUARTER_JSON_S22 = """
+                    {
+                        "quarter": "20222",
+                        "qyy": "S22",
+                        "name": "SPRING 2022",
+                        "category": "SPRING",
+                        "academicYear": "2021-2022",
+                        "firstDayOfClasses": "2022-03-28T00:00:00",
+                        "lastDayOfClasses": "2022-06-10T00:00:00",
+                        "firstDayOfFinals": "2022-06-11T00:00:00",
+                        "lastDayOfFinals": "2022-06-17T00:00:00",
+                        "firstDayOfQuarter": "2022-03-28T00:00:00",
+                        "lastDayOfSchedule": "2022-06-25T00:00:00",
+                        "pass1Begin": "2021-12-27T09:00:00",
+                        "pass2Begin": "2022-01-10T09:00:00",
+                        "pass3Begin": "2022-01-24T09:00:00",
+                        "feeDeadline": "2022-03-14T00:00:00",
+                        "lastDayToAddUnderGrad": "2022-04-18T00:00:00",
+                        "lastDayToAddGrad": "2022-04-18T00:00:00",
+                        "lastDayThirdWeek": "2022-04-19T00:00:00"
+                    }
+            """;
+
+    public static final String SAMPLE_QUARTER_JSON_M22 = """
+                    {
+                        "quarter": "20223",
+                        "qyy": "M22",
+                        "name": "SUMMER 2022",
+                        "category": "SUMMER",
+                        "academicYear": "2021-2022",
+                        "firstDayOfClasses": "2022-06-27T00:00:00",
+                        "lastDayOfClasses": "2022-09-09T00:00:00",
+                        "firstDayOfFinals": "2022-09-10T00:00:00",
+                        "lastDayOfFinals": "2022-09-16T00:00:00",
+                        "firstDayOfQuarter": "2022-06-27T00:00:00",
+                        "lastDayOfSchedule": "2022-09-17T00:00:00",
+                        "pass1Begin": "2022-02-07T09:00:00",
+                        "pass2Begin": "2022-02-21T09:00:00",
+                        "pass3Begin": "2022-03-07T09:00:00",
+                        "feeDeadline": "2022-06-14T00:00:00",
+                        "lastDayToAddUnderGrad": "2022-07-11T00:00:00",
+                        "lastDayToAddGrad": "2022-07-11T00:00:00",
+                        "lastDayThirdWeek": "2022-07-12T00:00:00"
+                    }
+            """;
+
 }

--- a/src/main/java/edu/ucsb/cs156/courses/entities/UCSBAPIQuarter.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/UCSBAPIQuarter.java
@@ -14,27 +14,27 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity(name = "ucsbapiquarter")
 public class UCSBAPIQuarter {
-    @Id
-    private String quarter; // example: 20243
-    private String qyy; // example: M24
-    private String name; // example: SUMMER 2024
-    private String category; // example: SUMMER
-    private String academicYear; // example: 2023-2024
-    private LocalDateTime firstDayOfClasses; // example: 2024-06-24T00:00:00
-    private LocalDateTime lastDayOfClasses; // example: 2024-09-13T00:00:00
-    private LocalDateTime firstDayOfFinals; // example: 2024-09-14T00:00:00
-    private LocalDateTime lastDayOfFinals; // example: 2024-09-14T00:00:00
-    private LocalDateTime firstDayOfQuarter; // example: 2024-06-24T00:00:00
-    private LocalDateTime lastDayOfSchedule; // example: 2024-09-21T00:00:00
-    private LocalDateTime pass1Begin; // example: 2024-04-08T09:00:00
-    private LocalDateTime pass2Begin; // example: 2024-04-22T09:00:00
-    private LocalDateTime pass3Begin; // example: 2024-05-06T09:00:00
-    private LocalDateTime feeDeadline; // example: 2024-06-26T00:00:00
-    private LocalDateTime lastDayToAddUnderGrad; // example: 2024-07-15T00:00:00
-    private LocalDateTime lastDayToAddGrad; // example: 2024-09-13T00:00:00
-    private LocalDateTime lastDayThirdWeek; // example: null
+  @Id private String quarter; // example: 20243
+  private String qyy; // example: M24
+  private String name; // example: SUMMER 2024
+  private String category; // example: SUMMER
+  private String academicYear; // example: 2023-2024
+  private LocalDateTime firstDayOfClasses; // example: 2024-06-24T00:00:00
+  private LocalDateTime lastDayOfClasses; // example: 2024-09-13T00:00:00
+  private LocalDateTime firstDayOfFinals; // example: 2024-09-14T00:00:00
+  private LocalDateTime lastDayOfFinals; // example: 2024-09-14T00:00:00
+  private LocalDateTime firstDayOfQuarter; // example: 2024-06-24T00:00:00
+  private LocalDateTime lastDayOfSchedule; // example: 2024-09-21T00:00:00
+  private LocalDateTime pass1Begin; // example: 2024-04-08T09:00:00
+  private LocalDateTime pass2Begin; // example: 2024-04-22T09:00:00
+  private LocalDateTime pass3Begin; // example: 2024-05-06T09:00:00
+  private LocalDateTime feeDeadline; // example: 2024-06-26T00:00:00
+  private LocalDateTime lastDayToAddUnderGrad; // example: 2024-07-15T00:00:00
+  private LocalDateTime lastDayToAddGrad; // example: 2024-09-13T00:00:00
+  private LocalDateTime lastDayThirdWeek; // example: null
 
-    public static final String SAMPLE_QUARTER_JSON_M24 = """
+  public static final String SAMPLE_QUARTER_JSON_M24 =
+      """
                 {
                     "quarter": "20243",
                     "qyy": "M24",
@@ -57,7 +57,8 @@ public class UCSBAPIQuarter {
                 }
             """;
 
-    public static final String SAMPLE_QUARTER_JSON_F20 = """
+  public static final String SAMPLE_QUARTER_JSON_F20 =
+      """
                     {
                         "quarter": "20204",
                         "qyy": "F20",
@@ -80,7 +81,8 @@ public class UCSBAPIQuarter {
                     }
             """;
 
-    public static final String SAMPLE_QUARTER_JSON_W21 = """
+  public static final String SAMPLE_QUARTER_JSON_W21 =
+      """
                     {
                         "quarter": "20211",
                         "qyy": "W21",
@@ -103,7 +105,8 @@ public class UCSBAPIQuarter {
                     },
             """;
 
-    public static final String SAMPLE_QUARTER_JSON_S21 = """
+  public static final String SAMPLE_QUARTER_JSON_S21 =
+      """
                     {
                         "quarter": "20212",
                         "qyy": "S21",
@@ -126,7 +129,8 @@ public class UCSBAPIQuarter {
                     }
             """;
 
-    public static final String SAMPLE_QUARTER_JSON_M21 = """
+  public static final String SAMPLE_QUARTER_JSON_M21 =
+      """
                     {
                         "quarter": "20213",
                         "qyy": "M21",
@@ -149,7 +153,8 @@ public class UCSBAPIQuarter {
                     }
             """;
 
-    public static final String SAMPLE_QUARTER_JSON_F21 = """
+  public static final String SAMPLE_QUARTER_JSON_F21 =
+      """
                     {
                         "quarter": "20214",
                         "qyy": "F21",
@@ -171,7 +176,8 @@ public class UCSBAPIQuarter {
                         "lastDayThirdWeek": "2021-10-19T00:00:00"
                     }
             """;
-    public static final String SAMPLE_QUARTER_JSON_W22 = """
+  public static final String SAMPLE_QUARTER_JSON_W22 =
+      """
                     {
                         "quarter": "20221",
                         "qyy": "W22",
@@ -194,7 +200,8 @@ public class UCSBAPIQuarter {
                     }
             """;
 
-    public static final String SAMPLE_QUARTER_JSON_S22 = """
+  public static final String SAMPLE_QUARTER_JSON_S22 =
+      """
                     {
                         "quarter": "20222",
                         "qyy": "S22",
@@ -217,7 +224,8 @@ public class UCSBAPIQuarter {
                     }
             """;
 
-    public static final String SAMPLE_QUARTER_JSON_M22 = """
+  public static final String SAMPLE_QUARTER_JSON_M22 =
+      """
                     {
                         "quarter": "20223",
                         "qyy": "M22",
@@ -239,5 +247,4 @@ public class UCSBAPIQuarter {
                         "lastDayThirdWeek": "2022-07-12T00:00:00"
                     }
             """;
-
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
 import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,11 +33,9 @@ public class UCSBAPIQuarterService {
   @Value("${app.endQtrYYYYQ:20222}")
   private String endQtrYYYYQ;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-  @Autowired
-  UCSBAPIQuarterRepository ucsbApiQuarterRepository;
+  @Autowired UCSBAPIQuarterRepository ucsbApiQuarterRepository;
 
   @Value("${app.ucsb.api.consumer_key}")
   private String apiKey;
@@ -49,11 +46,14 @@ public class UCSBAPIQuarterService {
     restTemplate = restTemplateBuilder.build();
   }
 
-  public static final String CURRENT_QUARTER_ENDPOINT = "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/current";
+  public static final String CURRENT_QUARTER_ENDPOINT =
+      "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/current";
 
-  public static final String ALL_QUARTERS_ENDPOINT = "https://api.ucsb.edu/academics/quartercalendar/v1/quarters";
+  public static final String ALL_QUARTERS_ENDPOINT =
+      "https://api.ucsb.edu/academics/quartercalendar/v1/quarters";
 
-  public static final String END_QUARTER_ENDPOINT = "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/end";
+  public static final String END_QUARTER_ENDPOINT =
+      "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/end";
 
   public String getStartQtrYYYYQ() {
     return startQtrYYYYQ;
@@ -148,8 +148,7 @@ public class UCSBAPIQuarterService {
         statusCode,
         entity);
     List<UCSBAPIQuarter> quarters = null;
-    quarters = objectMapper.readValue(retVal, new TypeReference<List<UCSBAPIQuarter>>() {
-    });
+    quarters = objectMapper.readValue(retVal, new TypeReference<List<UCSBAPIQuarter>>() {});
     return quarters;
   }
 
@@ -198,7 +197,9 @@ public class UCSBAPIQuarterService {
       return null;
     }
 
-    return lastDayToAddUndergrad.isAfter(lastDayToAddGrad) ? lastDayToAddUndergrad : lastDayToAddGrad;
+    return lastDayToAddUndergrad.isAfter(lastDayToAddGrad)
+        ? lastDayToAddUndergrad
+        : lastDayToAddGrad;
   }
 
   public boolean isQuarterInRegistrationPass(String quarterYYYYQ) {
@@ -227,8 +228,8 @@ public class UCSBAPIQuarterService {
 
     List<String> activeQuarters = getActiveQuarters();
 
-    List<String> registrationQuarters = activeQuarters.stream().filter(yyyyq -> isQuarterInRegistrationPass(yyyyq))
-        .toList();
+    List<String> registrationQuarters =
+        activeQuarters.stream().filter(yyyyq -> isQuarterInRegistrationPass(yyyyq)).toList();
     return registrationQuarters;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
 import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,9 +34,11 @@ public class UCSBAPIQuarterService {
   @Value("${app.endQtrYYYYQ:20222}")
   private String endQtrYYYYQ;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  private ObjectMapper objectMapper;
 
-  @Autowired UCSBAPIQuarterRepository ucsbApiQuarterRepository;
+  @Autowired
+  UCSBAPIQuarterRepository ucsbApiQuarterRepository;
 
   @Value("${app.ucsb.api.consumer_key}")
   private String apiKey;
@@ -45,14 +49,11 @@ public class UCSBAPIQuarterService {
     restTemplate = restTemplateBuilder.build();
   }
 
-  public static final String CURRENT_QUARTER_ENDPOINT =
-      "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/current";
+  public static final String CURRENT_QUARTER_ENDPOINT = "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/current";
 
-  public static final String ALL_QUARTERS_ENDPOINT =
-      "https://api.ucsb.edu/academics/quartercalendar/v1/quarters";
+  public static final String ALL_QUARTERS_ENDPOINT = "https://api.ucsb.edu/academics/quartercalendar/v1/quarters";
 
-  public static final String END_QUARTER_ENDPOINT =
-      "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/end";
+  public static final String END_QUARTER_ENDPOINT = "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/end";
 
   public String getStartQtrYYYYQ() {
     return startQtrYYYYQ;
@@ -147,7 +148,8 @@ public class UCSBAPIQuarterService {
         statusCode,
         entity);
     List<UCSBAPIQuarter> quarters = null;
-    quarters = objectMapper.readValue(retVal, new TypeReference<List<UCSBAPIQuarter>>() {});
+    quarters = objectMapper.readValue(retVal, new TypeReference<List<UCSBAPIQuarter>>() {
+    });
     return quarters;
   }
 
@@ -182,5 +184,51 @@ public class UCSBAPIQuarterService {
     }
 
     return activeQuarters;
+  }
+
+  public LocalDateTime lastDayToRegister(UCSBAPIQuarter ucsbApiQuarter) {
+    if (ucsbApiQuarter == null) {
+      return null;
+    }
+
+    LocalDateTime lastDayToAddUndergrad = ucsbApiQuarter.getLastDayToAddUnderGrad();
+    LocalDateTime lastDayToAddGrad = ucsbApiQuarter.getLastDayToAddGrad();
+
+    if (lastDayToAddUndergrad == null || lastDayToAddGrad == null) {
+      return null;
+    }
+
+    return lastDayToAddUndergrad.isAfter(lastDayToAddGrad) ? lastDayToAddUndergrad : lastDayToAddGrad;
+  }
+
+  public boolean isQuarterInRegistrationPass(String quarterYYYYQ) {
+    UCSBAPIQuarter quarter = ucsbApiQuarterRepository.findById(quarterYYYYQ).orElse(null);
+    LocalDateTime lastDay = lastDayToRegister(quarter);
+
+    if (quarter == null) {
+      return false;
+    }
+
+    if (lastDay == null) {
+      return false;
+    }
+
+    LocalDateTime pass1Begin = quarter.getPass1Begin();
+
+    if (pass1Begin == null) {
+      return false;
+    }
+
+    LocalDateTime currentDate = LocalDateTime.now();
+    return currentDate.isAfter(pass1Begin) && currentDate.isBefore(lastDay);
+  }
+
+  public List<String> getActiveRegistrationQuarters() throws Exception {
+
+    List<String> activeQuarters = getActiveQuarters();
+
+    List<String> registrationQuarters = activeQuarters.stream().filter(yyyyq -> isQuarterInRegistrationPass(yyyyq))
+        .toList();
+    return registrationQuarters;
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
@@ -12,12 +12,10 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
 import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -34,30 +32,26 @@ import org.springframework.web.client.RestTemplate;
 
 @RestClientTest(UCSBAPIQuarterService.class)
 @AutoConfigureDataJpa
-@TestPropertySource(properties = {
-    "app.startQtrYYYYQ=20211",
-    "app.endQtrYYYYQ=20223",
-    "app.ucsb.api.consumer_key=fakeApiKey"
-})
+@TestPropertySource(
+    properties = {
+      "app.startQtrYYYYQ=20211",
+      "app.endQtrYYYYQ=20223",
+      "app.ucsb.api.consumer_key=fakeApiKey"
+    })
 public class UCSBAPIQuarterServiceTests {
 
   @Value("${app.ucsb.api.consumer_key}")
   private String apiKey;
 
-  @Autowired
-  private MockRestServiceServer mockRestServiceServer;
+  @Autowired private MockRestServiceServer mockRestServiceServer;
 
-  @Mock
-  private RestTemplate restTemplate;
+  @Mock private RestTemplate restTemplate;
 
-  @MockBean
-  private UCSBAPIQuarterRepository ucsbApiQuarterRepository;
+  @MockBean private UCSBAPIQuarterRepository ucsbApiQuarterRepository;
 
-  @Autowired
-  private UCSBAPIQuarterService service;
+  @Autowired private UCSBAPIQuarterService service;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   @Test
   public void test_getStartQtrYYYYQ() {
@@ -87,8 +81,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getCurrentQuarter() throws Exception {
-    UCSBAPIQuarter expectedResult = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24,
-        UCSBAPIQuarter.class);
+    UCSBAPIQuarter expectedResult =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
 
@@ -108,7 +102,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getAllQuartersFromAPI() throws Exception {
-    UCSBAPIQuarter sampleQuarter = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleQuarter =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(sampleQuarter);
@@ -131,7 +126,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarters() throws Exception {
-    UCSBAPIQuarter sampleCurrent = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleCurrent =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
     String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
     this.mockRestServiceServer
@@ -142,7 +138,8 @@ public class UCSBAPIQuarterServiceTests {
         .andExpect(header("ucsb-api-key", apiKey))
         .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
 
-    List<String> expectedResult = List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
+    List<String> expectedResult =
+        List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
     List<String> actualResult = service.getActiveQuarters();
 
     assertEquals(expectedResult, actualResult);
@@ -150,7 +147,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarters_returns_no_past_quarters() throws Exception {
-    UCSBAPIQuarter sampleCurrent = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleCurrent =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
     String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
     this.mockRestServiceServer
@@ -169,7 +167,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarters_returns_one_value_when_current_equals_end() throws Exception {
-    UCSBAPIQuarter sampleCurrent = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleCurrent =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
     sampleCurrent.setQuarter("20223");
     String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
@@ -189,7 +188,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getAllQuarters_preloaded() throws Exception {
-    UCSBAPIQuarter sampleQuarter = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleQuarter =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(sampleQuarter);
@@ -204,9 +204,12 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getAllQuarters_empty() throws Exception {
-    UCSBAPIQuarter F20 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_F20, UCSBAPIQuarter.class);
-    UCSBAPIQuarter W21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
-    UCSBAPIQuarter M23 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter F20 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_F20, UCSBAPIQuarter.class);
+    UCSBAPIQuarter W21 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter M23 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> emptyList = new ArrayList<UCSBAPIQuarter>();
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
@@ -241,7 +244,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarterList() throws Exception {
-    UCSBAPIQuarter sampleQuarter = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleQuarter =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
     String expectedJSON = objectMapper.writeValueAsString(sampleQuarter);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
     this.mockRestServiceServer
@@ -252,7 +256,8 @@ public class UCSBAPIQuarterServiceTests {
         .andExpect(header("ucsb-api-key", apiKey))
         .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
 
-    List<String> expectedResult = List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
+    List<String> expectedResult =
+        List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
     List<String> actualResult = service.getActiveQuarterList();
 
     assertEquals(expectedResult, actualResult);
@@ -301,17 +306,19 @@ public class UCSBAPIQuarterServiceTests {
   @Test
   public void test_lastDayToRegister_pass1Begin_null() {
 
-    UCSBAPIQuarter quarter = new UCSBAPIQuarter(); // null pass1Begin, lastDayToAddUnderGrad, lastDayToAddGrad
+    UCSBAPIQuarter quarter =
+        new UCSBAPIQuarter(); // null pass1Begin, lastDayToAddUnderGrad, lastDayToAddGrad
     assertEquals(null, service.lastDayToRegister(quarter));
   }
 
   @Test
   public void test_lastDayToRegister_lastDayToAddUnderGrad_null() {
 
-    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
-        .build();
+    UCSBAPIQuarter quarter =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+            .build();
 
     assertEquals(null, service.lastDayToRegister(quarter));
   }
@@ -319,11 +326,12 @@ public class UCSBAPIQuarterServiceTests {
   @Test
   public void test_lastDayToRegister_lastDayToAddGrad_null() {
 
-    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
-        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .build();
+    UCSBAPIQuarter quarter =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+            .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .build();
 
     assertEquals(null, service.lastDayToRegister(quarter));
   }
@@ -331,12 +339,13 @@ public class UCSBAPIQuarterServiceTests {
   @Test
   public void test_lastDayToRegister_Undergrad_Later() {
 
-    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
-        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
-        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .build();
+    UCSBAPIQuarter quarter =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+            .lastDayToAddUnderGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
+            .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .build();
 
     assertEquals(LocalDateTime.parse("2021-02-15T00:00:00"), service.lastDayToRegister(quarter));
   }
@@ -344,12 +353,13 @@ public class UCSBAPIQuarterServiceTests {
   @Test
   public void test_lastDayToRegister_Grad_Later() {
 
-    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
-        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
-        .lastDayToAddGrad(LocalDateTime.parse("2021-02-20T00:00:00"))
-        .build();
+    UCSBAPIQuarter quarter =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+            .lastDayToAddUnderGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
+            .lastDayToAddGrad(LocalDateTime.parse("2021-02-20T00:00:00"))
+            .build();
 
     assertEquals(LocalDateTime.parse("2021-02-20T00:00:00"), service.lastDayToRegister(quarter));
   }
@@ -361,84 +371,99 @@ public class UCSBAPIQuarterServiceTests {
   }
 
   @Test
-  public void test_isQuarterRegistrationPass_findById_returns_quarter_with_null_values_then_false() {
-    UCSBAPIQuarter quarterWithNullValues = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(null)
-        .lastDayToAddUnderGrad(null)
-        .lastDayToAddGrad(null)
-        .build();
-    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarterWithNullValues));
+  public void
+      test_isQuarterRegistrationPass_findById_returns_quarter_with_null_values_then_false() {
+    UCSBAPIQuarter quarterWithNullValues =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(null)
+            .lastDayToAddUnderGrad(null)
+            .lastDayToAddGrad(null)
+            .build();
+    when(ucsbApiQuarterRepository.findById(eq("20211")))
+        .thenReturn(Optional.of(quarterWithNullValues));
     assertEquals(false, service.isQuarterInRegistrationPass("20211"));
   }
 
   @Test
-  public void test_isQuarterRegistrationPass_findById_returns_quarter_with_pass1_null_returns_false() {
-    UCSBAPIQuarter quarterWithNullValues = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(null)
-        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .lastDayToAddGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
-        .build();
-    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarterWithNullValues));
+  public void
+      test_isQuarterRegistrationPass_findById_returns_quarter_with_pass1_null_returns_false() {
+    UCSBAPIQuarter quarterWithNullValues =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(null)
+            .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .lastDayToAddGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
+            .build();
+    when(ucsbApiQuarterRepository.findById(eq("20211")))
+        .thenReturn(Optional.of(quarterWithNullValues));
     assertEquals(false, service.isQuarterInRegistrationPass("20211"));
   }
 
   @Test
-  public void test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_but_date_before_pass1() {
+  public void
+      test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_but_date_before_pass1() {
     // Arrange
-    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
-        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .build();
+    UCSBAPIQuarter quarter =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+            .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .build();
 
     when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarter));
 
     LocalDateTime fixedDateTime = LocalDateTime.parse("2020-10-01T00:00:00");
 
-    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime =
+        Mockito.mockStatic(LocalDateTime.class)) {
       mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
       assertEquals(false, service.isQuarterInRegistrationPass("20211"));
     }
   }
 
   @Test
-  public void test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_but_date_after_last_day() {
+  public void
+      test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_but_date_after_last_day() {
     // Arrange
-    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
-        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .build();
+    UCSBAPIQuarter quarter =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+            .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .build();
 
     when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarter));
 
     LocalDateTime fixedDateTime = LocalDateTime.parse("2021-04-01T00:00:00");
 
-    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime =
+        Mockito.mockStatic(LocalDateTime.class)) {
       mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
       assertEquals(false, service.isQuarterInRegistrationPass("20211"));
     }
   }
 
   @Test
-  public void test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_and_date_is_in_range() {
+  public void
+      test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_and_date_is_in_range() {
     // Arrange
-    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
-        .quarter("20211")
-        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
-        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
-        .build();
+    UCSBAPIQuarter quarter =
+        UCSBAPIQuarter.builder()
+            .quarter("20211")
+            .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+            .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+            .build();
 
     when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarter));
 
     LocalDateTime fixedDateTime = LocalDateTime.parse("2020-11-02T00:00:00");
 
-    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime =
+        Mockito.mockStatic(LocalDateTime.class)) {
       mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
       assertEquals(true, service.isQuarterInRegistrationPass("20211"));
     }
@@ -446,13 +471,20 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveRegistrationQuarters() throws Exception {
-    UCSBAPIQuarter W21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
-    UCSBAPIQuarter S21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_S21, UCSBAPIQuarter.class);
-    UCSBAPIQuarter M21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M21, UCSBAPIQuarter.class);
-    UCSBAPIQuarter F21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_F21, UCSBAPIQuarter.class);
-    UCSBAPIQuarter W22 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W22, UCSBAPIQuarter.class);
-    UCSBAPIQuarter S22 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_S22, UCSBAPIQuarter.class);
-    UCSBAPIQuarter M22 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M22, UCSBAPIQuarter.class);
+    UCSBAPIQuarter W21 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter S21 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_S21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter M21 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter F21 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_F21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter W22 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W22, UCSBAPIQuarter.class);
+    UCSBAPIQuarter S22 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_S22, UCSBAPIQuarter.class);
+    UCSBAPIQuarter M22 =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M22, UCSBAPIQuarter.class);
 
     String expectedJSON = objectMapper.writeValueAsString(W21);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
@@ -471,20 +503,17 @@ public class UCSBAPIQuarterServiceTests {
     when(ucsbApiQuarterRepository.findById(eq("20221"))).thenReturn(Optional.of(W22));
     when(ucsbApiQuarterRepository.findById(eq("20222"))).thenReturn(Optional.of(S22));
     when(ucsbApiQuarterRepository.findById(eq("20223"))).thenReturn(Optional.of(M22));
-    
+
     LocalDateTime fixedDateTime = LocalDateTime.parse("2021-02-09T00:00:00");
 
-    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime =
+        Mockito.mockStatic(LocalDateTime.class)) {
       mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
 
       List<String> expectedResult = List.of("20212", "20213");
       List<String> actualResult = service.getActiveRegistrationQuarters();
-  
+
       assertEquals(expectedResult, actualResult);
-
     }
-
   }
 }
-
-

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
@@ -12,10 +12,16 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
 import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -28,26 +34,30 @@ import org.springframework.web.client.RestTemplate;
 
 @RestClientTest(UCSBAPIQuarterService.class)
 @AutoConfigureDataJpa
-@TestPropertySource(
-    properties = {
-      "app.startQtrYYYYQ=20211",
-      "app.endQtrYYYYQ=20223",
-      "app.ucsb.api.consumer_key=fakeApiKey"
-    })
+@TestPropertySource(properties = {
+    "app.startQtrYYYYQ=20211",
+    "app.endQtrYYYYQ=20223",
+    "app.ucsb.api.consumer_key=fakeApiKey"
+})
 public class UCSBAPIQuarterServiceTests {
 
   @Value("${app.ucsb.api.consumer_key}")
   private String apiKey;
 
-  @Autowired private MockRestServiceServer mockRestServiceServer;
+  @Autowired
+  private MockRestServiceServer mockRestServiceServer;
 
-  @Mock private RestTemplate restTemplate;
+  @Mock
+  private RestTemplate restTemplate;
 
-  @MockBean private UCSBAPIQuarterRepository ucsbApiQuarterRepository;
+  @MockBean
+  private UCSBAPIQuarterRepository ucsbApiQuarterRepository;
 
-  @Autowired private UCSBAPIQuarterService service;
+  @Autowired
+  private UCSBAPIQuarterService service;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  private ObjectMapper objectMapper;
 
   @Test
   public void test_getStartQtrYYYYQ() {
@@ -77,8 +87,8 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getCurrentQuarter() throws Exception {
-    UCSBAPIQuarter expectedResult =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter expectedResult = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24,
+        UCSBAPIQuarter.class);
 
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
 
@@ -98,8 +108,7 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getAllQuartersFromAPI() throws Exception {
-    UCSBAPIQuarter sampleQuarter =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleQuarter = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(sampleQuarter);
@@ -122,8 +131,7 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarters() throws Exception {
-    UCSBAPIQuarter sampleCurrent =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleCurrent = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
     String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
     this.mockRestServiceServer
@@ -134,8 +142,7 @@ public class UCSBAPIQuarterServiceTests {
         .andExpect(header("ucsb-api-key", apiKey))
         .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
 
-    List<String> expectedResult =
-        List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
+    List<String> expectedResult = List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
     List<String> actualResult = service.getActiveQuarters();
 
     assertEquals(expectedResult, actualResult);
@@ -143,8 +150,7 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarters_returns_no_past_quarters() throws Exception {
-    UCSBAPIQuarter sampleCurrent =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleCurrent = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
     String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
     this.mockRestServiceServer
@@ -163,8 +169,7 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarters_returns_one_value_when_current_equals_end() throws Exception {
-    UCSBAPIQuarter sampleCurrent =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleCurrent = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
     sampleCurrent.setQuarter("20223");
     String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
@@ -184,8 +189,7 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getAllQuarters_preloaded() throws Exception {
-    UCSBAPIQuarter sampleQuarter =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleQuarter = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
     expectedResult.add(sampleQuarter);
@@ -200,12 +204,9 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getAllQuarters_empty() throws Exception {
-    UCSBAPIQuarter F20 =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_F20, UCSBAPIQuarter.class);
-    UCSBAPIQuarter W21 =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
-    UCSBAPIQuarter M23 =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    UCSBAPIQuarter F20 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_F20, UCSBAPIQuarter.class);
+    UCSBAPIQuarter W21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter M23 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
 
     List<UCSBAPIQuarter> emptyList = new ArrayList<UCSBAPIQuarter>();
     List<UCSBAPIQuarter> expectedResult = new ArrayList<UCSBAPIQuarter>();
@@ -240,8 +241,7 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_getActiveQuarterList() throws Exception {
-    UCSBAPIQuarter sampleQuarter =
-        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter sampleQuarter = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
     String expectedJSON = objectMapper.writeValueAsString(sampleQuarter);
     String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
     this.mockRestServiceServer
@@ -252,8 +252,7 @@ public class UCSBAPIQuarterServiceTests {
         .andExpect(header("ucsb-api-key", apiKey))
         .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
 
-    List<String> expectedResult =
-        List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
+    List<String> expectedResult = List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
     List<String> actualResult = service.getActiveQuarterList();
 
     assertEquals(expectedResult, actualResult);
@@ -293,4 +292,199 @@ public class UCSBAPIQuarterServiceTests {
   public void test_quarterYYYYQInRange_20231_false() {
     assertEquals(false, service.quarterYYYYQInRange("20231"));
   }
+
+  @Test
+  public void test_lastDayToRegister_null() {
+    assertEquals(null, service.lastDayToRegister(null));
+  }
+
+  @Test
+  public void test_lastDayToRegister_pass1Begin_null() {
+
+    UCSBAPIQuarter quarter = new UCSBAPIQuarter(); // null pass1Begin, lastDayToAddUnderGrad, lastDayToAddGrad
+    assertEquals(null, service.lastDayToRegister(quarter));
+  }
+
+  @Test
+  public void test_lastDayToRegister_lastDayToAddUnderGrad_null() {
+
+    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+        .build();
+
+    assertEquals(null, service.lastDayToRegister(quarter));
+  }
+
+  @Test
+  public void test_lastDayToRegister_lastDayToAddGrad_null() {
+
+    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .build();
+
+    assertEquals(null, service.lastDayToRegister(quarter));
+  }
+
+  @Test
+  public void test_lastDayToRegister_Undergrad_Later() {
+
+    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
+        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .build();
+
+    assertEquals(LocalDateTime.parse("2021-02-15T00:00:00"), service.lastDayToRegister(quarter));
+  }
+
+  @Test
+  public void test_lastDayToRegister_Grad_Later() {
+
+    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
+        .lastDayToAddGrad(LocalDateTime.parse("2021-02-20T00:00:00"))
+        .build();
+
+    assertEquals(LocalDateTime.parse("2021-02-20T00:00:00"), service.lastDayToRegister(quarter));
+  }
+
+  @Test
+  public void test_isQuarterRegistrationPass_findById_returns_null_then_false() {
+    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.empty());
+    assertEquals(false, service.isQuarterInRegistrationPass("20211"));
+  }
+
+  @Test
+  public void test_isQuarterRegistrationPass_findById_returns_quarter_with_null_values_then_false() {
+    UCSBAPIQuarter quarterWithNullValues = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(null)
+        .lastDayToAddUnderGrad(null)
+        .lastDayToAddGrad(null)
+        .build();
+    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarterWithNullValues));
+    assertEquals(false, service.isQuarterInRegistrationPass("20211"));
+  }
+
+  @Test
+  public void test_isQuarterRegistrationPass_findById_returns_quarter_with_pass1_null_returns_false() {
+    UCSBAPIQuarter quarterWithNullValues = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(null)
+        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .lastDayToAddGrad(LocalDateTime.parse("2021-02-15T00:00:00"))
+        .build();
+    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarterWithNullValues));
+    assertEquals(false, service.isQuarterInRegistrationPass("20211"));
+  }
+
+  @Test
+  public void test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_but_date_before_pass1() {
+    // Arrange
+    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .build();
+
+    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarter));
+
+    LocalDateTime fixedDateTime = LocalDateTime.parse("2020-10-01T00:00:00");
+
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+      mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
+      assertEquals(false, service.isQuarterInRegistrationPass("20211"));
+    }
+  }
+
+  @Test
+  public void test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_but_date_after_last_day() {
+    // Arrange
+    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .build();
+
+    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarter));
+
+    LocalDateTime fixedDateTime = LocalDateTime.parse("2021-04-01T00:00:00");
+
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+      mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
+      assertEquals(false, service.isQuarterInRegistrationPass("20211"));
+    }
+  }
+
+  @Test
+  public void test_isQuarterRegistrationPass_20211_findById_returns_object_with_good_values_and_date_is_in_range() {
+    // Arrange
+    UCSBAPIQuarter quarter = UCSBAPIQuarter.builder()
+        .quarter("20211")
+        .pass1Begin(LocalDateTime.parse("2020-11-01T00:00:00"))
+        .lastDayToAddUnderGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .lastDayToAddGrad(LocalDateTime.parse("2021-01-15T00:00:00"))
+        .build();
+
+    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(quarter));
+
+    LocalDateTime fixedDateTime = LocalDateTime.parse("2020-11-02T00:00:00");
+
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+      mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
+      assertEquals(true, service.isQuarterInRegistrationPass("20211"));
+    }
+  }
+
+  @Test
+  public void test_getActiveRegistrationQuarters() throws Exception {
+    UCSBAPIQuarter W21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter S21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_S21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter M21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter F21 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_F21, UCSBAPIQuarter.class);
+    UCSBAPIQuarter W22 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W22, UCSBAPIQuarter.class);
+    UCSBAPIQuarter S22 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_S22, UCSBAPIQuarter.class);
+    UCSBAPIQuarter M22 = objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M22, UCSBAPIQuarter.class);
+
+    String expectedJSON = objectMapper.writeValueAsString(W21);
+    String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
+
+    when(ucsbApiQuarterRepository.findById(eq("20211"))).thenReturn(Optional.of(W21));
+    when(ucsbApiQuarterRepository.findById(eq("20212"))).thenReturn(Optional.of(S21));
+    when(ucsbApiQuarterRepository.findById(eq("20213"))).thenReturn(Optional.of(M21));
+    when(ucsbApiQuarterRepository.findById(eq("20214"))).thenReturn(Optional.of(F21));
+    when(ucsbApiQuarterRepository.findById(eq("20221"))).thenReturn(Optional.of(W22));
+    when(ucsbApiQuarterRepository.findById(eq("20222"))).thenReturn(Optional.of(S22));
+    when(ucsbApiQuarterRepository.findById(eq("20223"))).thenReturn(Optional.of(M22));
+    
+    LocalDateTime fixedDateTime = LocalDateTime.parse("2021-02-09T00:00:00");
+
+    try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
+      mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedDateTime);
+
+      List<String> expectedResult = List.of("20212", "20213");
+      List<String> actualResult = service.getActiveRegistrationQuarters();
+  
+      assertEquals(expectedResult, actualResult);
+
+    }
+
+  }
 }
+
+


### PR DESCRIPTION
In this PR we add a new method to the UCSBAPIQuarterService that will return a list of the quarters that are in active registration passes.

This is for a future job that will record stats on registration during active registration passes

Closes #171 


