### PR TITLE
Pc enrollment data entity

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.courses.entities;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * GradeHistory - Entity for grade history data. Each object represents one row from the CSV files
+ * located in this repository: <a href=
+ * "https://github.com/rtora/UCSB_Grades">https://github.com/rtora/UCSB_Grades</a>
+ *
+ * <p>There is a unique constraint on the combination of year, quarter, subjectArea, course,
+ * instructor, and grade, since we do not want duplicate rows of data for the same course.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "enrollmentdatapoint")
+public class EnrollmentDataPoint {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String yyyyq;
+  private String section;
+  private int enrollment;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
@@ -1,12 +1,9 @@
 package edu.ucsb.cs156.courses.entities;
 
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -5,6 +5,7 @@ import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.models.Quarter;
+import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
@@ -29,6 +30,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
   private UpdateCollection updateCollection;
   private IsStaleService isStaleService;
   private boolean ifStale;
+  private EnrollmentDataPointRepository enrollmentDataPointRepository;
 
   @Override
   public void accept(JobContext ctx) throws Exception {

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.courses.jobs;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.collections.UpdateCollection;
+import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
@@ -25,6 +26,8 @@ public class UpdateCourseDataJobFactory {
 
   @Autowired private IsStaleService isStaleService;
 
+  @Autowired private EnrollmentDataPointRepository enrollmentDataPointRepository;
+
   public UpdateCourseDataJob createForSubjectAndQuarter(String subjectArea, String quarterYYYYQ) {
     return new UpdateCourseDataJob(
         quarterYYYYQ,
@@ -34,7 +37,8 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        false);
+        false,
+        enrollmentDataPointRepository);
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterAndIfStale(
@@ -47,7 +51,8 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        ifStale);
+        ifStale,
+        enrollmentDataPointRepository);
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterRange(
@@ -60,7 +65,8 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        true);
+        true,
+        enrollmentDataPointRepository);
   }
 
   private List<String> getAllSubjectCodes() {
@@ -81,7 +87,8 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        true);
+        true,
+        enrollmentDataPointRepository);
   }
 
   public UpdateCourseDataJob createForQuarterRange(
@@ -94,6 +101,7 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        true);
+        true,
+        enrollmentDataPointRepository);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.courses.repositories;
+
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EnrollmentDataPointRepository extends CrudRepository<EnrollmentDataPoint, Long> {
+ 
+}

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
@@ -5,6 +5,4 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EnrollmentDataPointRepository extends CrudRepository<EnrollmentDataPoint, Long> {
- 
-}
+public interface EnrollmentDataPointRepository extends CrudRepository<EnrollmentDataPoint, Long> {}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
@@ -30,6 +31,8 @@ public class UpdateCourseDataJobFactoryTests {
   @MockBean IsStaleService isStaleService;
 
   @Autowired UpdateCourseDataJobFactory factory;
+
+  @MockBean EnrollmentDataPointRepository enrollmentDataPointRepository;
 
   @Test
   void test_createForSubjectAndQuarter() {

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -35,8 +35,7 @@ public class UpdateCourseDataJobTests {
 
   @Mock IsStaleService isStaleService;
 
-  @Mock
-  EnrollmentDataPointRepository enrollmentDataPointRepository;
+  @Mock EnrollmentDataPointRepository enrollmentDataPointRepository;
 
   Job jobStarted = Job.builder().build();
   JobContext ctx = new JobContext(null, jobStarted);

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -12,6 +12,7 @@ import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
@@ -34,6 +35,9 @@ public class UpdateCourseDataJobTests {
 
   @Mock IsStaleService isStaleService;
 
+  @Mock
+  EnrollmentDataPointRepository enrollmentDataPointRepository;
+
   Job jobStarted = Job.builder().build();
   JobContext ctx = new JobContext(null, jobStarted);
 
@@ -50,6 +54,7 @@ public class UpdateCourseDataJobTests {
                 .updateCollection(updateCollection)
                 .isStaleService(isStaleService)
                 .ifStale(false)
+                .enrollmentDataPointRepository(enrollmentDataPointRepository)
                 .build());
     doNothing().when(job).updateCourses(any(), any(), any());
 
@@ -91,7 +96,8 @@ public class UpdateCourseDataJobTests {
             convertedSectionCollection,
             updateCollection,
             isStaleService,
-            false);
+            false,
+            enrollmentDataPointRepository);
     job.accept(ctx);
 
     // Assert
@@ -153,7 +159,8 @@ public class UpdateCourseDataJobTests {
             convertedSectionCollection,
             updateCollection,
             isStaleService,
-            false);
+            false,
+            enrollmentDataPointRepository);
     job.accept(ctx);
 
     // Assert
@@ -208,7 +215,8 @@ public class UpdateCourseDataJobTests {
             convertedSectionCollection,
             updateCollection,
             isStaleService,
-            false);
+            false,
+            enrollmentDataPointRepository);
     job.accept(ctx);
 
     // Assert
@@ -268,7 +276,8 @@ public class UpdateCourseDataJobTests {
             convertedSectionCollection,
             updateCollection,
             isStaleService,
-            false);
+            false,
+            enrollmentDataPointRepository);
     job.accept(ctx);
 
     // Assert
@@ -334,7 +343,8 @@ public class UpdateCourseDataJobTests {
             convertedSectionCollection,
             updateCollection,
             isStaleService,
-            true);
+            true,
+            enrollmentDataPointRepository);
     job.accept(ctx);
 
     // Assert
@@ -371,7 +381,8 @@ public class UpdateCourseDataJobTests {
             convertedSectionCollection,
             updateCollection,
             isStaleService,
-            true);
+            true,
+            enrollmentDataPointRepository);
     job.accept(ctx);
   }
 }


### PR DESCRIPTION
In this PR, we add a database table for EnrollmentDataPoints and make it available to the UpdateCourseDataJob.

We are not yet adding the logic to update the table; that will go in the next PR.

Closes #172 