### PR TITLE
pc - modify UpdateCourseDataJob to get enrollment data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v16.20.0</nodeVersion>
+                                    <nodeVersion>v20.17.0</nodeVersion>
                                 </configuration>
                             </execution>
                             <execution>

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -7,6 +7,10 @@ import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -31,5 +35,15 @@ public class ConvertedSection {
     newConvertedSection.setSection(newSection);
 
     return newConvertedSection;
+  }
+
+  @JsonIgnore
+  public EnrollmentDataPoint getEnrollmentDataPoint() {
+    EnrollmentDataPoint edp = EnrollmentDataPoint.builder()
+        .yyyyq(this.getCourseInfo().getQuarter())
+        .enrollCd(this.getSection().getEnrollCode())
+        .enrollment(this.getSection().getEnrolledTotal())
+        .build();
+    return edp;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -42,6 +42,8 @@ public class ConvertedSection {
             .yyyyq(this.getCourseInfo().getQuarter())
             .enrollCd(this.getSection().getEnrollCode())
             .enrollment(this.getSection().getEnrolledTotal())
+            .courseId(this.getCourseInfo().getCourseId())
+            .section(this.getSection().getSection())
             .build();
     return edp;
   }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -1,15 +1,13 @@
 package edu.ucsb.cs156.courses.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
 
 @Data
 @Builder
@@ -39,11 +37,12 @@ public class ConvertedSection {
 
   @JsonIgnore
   public EnrollmentDataPoint getEnrollmentDataPoint() {
-    EnrollmentDataPoint edp = EnrollmentDataPoint.builder()
-        .yyyyq(this.getCourseInfo().getQuarter())
-        .enrollCd(this.getSection().getEnrollCode())
-        .enrollment(this.getSection().getEnrolledTotal())
-        .build();
+    EnrollmentDataPoint edp =
+        EnrollmentDataPoint.builder()
+            .yyyyq(this.getCourseInfo().getQuarter())
+            .enrollCd(this.getSection().getEnrollCode())
+            .enrollment(this.getSection().getEnrolledTotal())
+            .build();
     return edp;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
@@ -73,22 +73,6 @@ public class Section implements Cloneable {
   public Object clone() throws CloneNotSupportedException {
 
     Section newSection = (Section) super.clone();
-    // List<String> copyConcurrentCourses = new ArrayList<>();
-    // Collections.copy(copyConcurrentCourses, this.getConcurrentCourses());
-    // newSection.setConcurrentCourses(copyConcurrentCourses);
-
-    // List<TimeLocation> copyTimeLocations = new ArrayList<>();
-    // for (TimeLocation tl : this.getTimeLocations()) {
-    //     copyTimeLocations.add((TimeLocation) tl.clone());
-    // }
-    // newSection.setTimeLocations(copyTimeLocations);
-
-    // List<Instructor> copyInstructors = new ArrayList<>();
-    // for (Instructor i : this.getInstructors()) {
-    //     copyInstructors.add((Instructor) i.clone());
-    // }
-    // newSection.setInstructors(copyInstructors);
-
     return newSection;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
@@ -28,6 +28,6 @@ public class EnrollmentDataPoint {
   private Long id;
 
   private String yyyyq;
-  private String section;
+  private String enrollCd;
   private int enrollment;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
@@ -1,13 +1,16 @@
 package edu.ucsb.cs156.courses.entities;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 /**
  * GradeHistory - Entity for grade history data. Each object represents one row from the CSV files
@@ -29,5 +32,11 @@ public class EnrollmentDataPoint {
 
   private String yyyyq;
   private String enrollCd;
+  private String courseId; // redundant but useful for querying since enrollCd is in Mongo
+  private String section; // redundant but useful for querying since enrollCd is in Mongo
   private int enrollment;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime dateCreated;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/EnrollmentDataPoint.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.courses.entities;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -11,6 +12,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * GradeHistory - Entity for grade history data. Each object represents one row from the CSV files
@@ -25,6 +27,7 @@ import org.springframework.data.annotation.CreatedDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity(name = "enrollmentdatapoint")
+@EntityListeners(AuditingEntityListener.class)
 public class EnrollmentDataPoint {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
+import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
@@ -31,6 +32,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
   private IsStaleService isStaleService;
   private boolean ifStale;
   private EnrollmentDataPointRepository enrollmentDataPointRepository;
+  private UCSBAPIQuarterService ucsbapiQuarterService;
 
   @Override
   public void accept(JobContext ctx) throws Exception {
@@ -88,6 +90,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           convertedSectionCollection.save(section);
           newSections++;
         }
+        
       } catch (Exception e) {
         errors++;
       }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -73,6 +73,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     int newSections = 0;
     int updatedSections = 0;
     int errors = 0;
+    boolean isInRegistrationPass = ucsbapiQuarterService.isQuarterInRegistrationPass(quarterYYYYQ);
 
     for (ConvertedSection section : convertedSections) {
       try {
@@ -90,7 +91,9 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           convertedSectionCollection.save(section);
           newSections++;
         }
-        
+        if (isInRegistrationPass) {
+          enrollmentDataPointRepository.save(section.getEnrollmentDataPoint());
+        }
       } catch (Exception e) {
         errors++;
       }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -42,8 +42,7 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         false,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService
-        );
+        ucsbapiQuarterService);
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterAndIfStale(
@@ -58,8 +57,7 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         ifStale,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService
-        );
+        ucsbapiQuarterService);
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterRange(
@@ -74,8 +72,7 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         true,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService
-        );
+        ucsbapiQuarterService);
   }
 
   private List<String> getAllSubjectCodes() {
@@ -98,8 +95,7 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         true,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService
-        );
+        ucsbapiQuarterService);
   }
 
   public UpdateCourseDataJob createForQuarterRange(
@@ -114,7 +110,6 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         true,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService
-        );
+        ucsbapiQuarterService);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -5,6 +5,7 @@ import edu.ucsb.cs156.courses.collections.UpdateCollection;
 import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
+import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,8 @@ public class UpdateCourseDataJobFactory {
 
   @Autowired private EnrollmentDataPointRepository enrollmentDataPointRepository;
 
+  @Autowired private UCSBAPIQuarterService ucsbapiQuarterService;
+
   public UpdateCourseDataJob createForSubjectAndQuarter(String subjectArea, String quarterYYYYQ) {
     return new UpdateCourseDataJob(
         quarterYYYYQ,
@@ -38,7 +41,9 @@ public class UpdateCourseDataJobFactory {
         updateCollection,
         isStaleService,
         false,
-        enrollmentDataPointRepository);
+        enrollmentDataPointRepository,
+        ucsbapiQuarterService
+        );
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterAndIfStale(
@@ -52,7 +57,9 @@ public class UpdateCourseDataJobFactory {
         updateCollection,
         isStaleService,
         ifStale,
-        enrollmentDataPointRepository);
+        enrollmentDataPointRepository,
+        ucsbapiQuarterService
+        );
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterRange(
@@ -66,7 +73,9 @@ public class UpdateCourseDataJobFactory {
         updateCollection,
         isStaleService,
         true,
-        enrollmentDataPointRepository);
+        enrollmentDataPointRepository,
+        ucsbapiQuarterService
+        );
   }
 
   private List<String> getAllSubjectCodes() {
@@ -88,7 +97,9 @@ public class UpdateCourseDataJobFactory {
         updateCollection,
         isStaleService,
         true,
-        enrollmentDataPointRepository);
+        enrollmentDataPointRepository,
+        ucsbapiQuarterService
+        );
   }
 
   public UpdateCourseDataJob createForQuarterRange(
@@ -102,6 +113,8 @@ public class UpdateCourseDataJobFactory {
         updateCollection,
         isStaleService,
         true,
-        enrollmentDataPointRepository);
+        enrollmentDataPointRepository,
+        ucsbapiQuarterService
+        );
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
@@ -5,9 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
-
 import java.util.List;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
@@ -44,8 +44,8 @@ public class ConvertedSectionTests {
 
     ConvertedSection cs1 = cs.get(0);
     EnrollmentDataPoint edp = cs1.getEnrollmentDataPoint();
-    assertEquals("20211", edp.getYyyyq());
-    assertEquals("10001", edp.getEnrollCd());
-    assertEquals(10, edp.getEnrollment());
+    assertEquals("20222", edp.getYyyyq());
+    assertEquals("30395", edp.getEnrollCd());
+    assertEquals(142, edp.getEnrollment());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
@@ -46,6 +46,8 @@ public class ConvertedSectionTests {
     EnrollmentDataPoint edp = cs1.getEnrollmentDataPoint();
     assertEquals("20222", edp.getYyyyq());
     assertEquals("30395", edp.getEnrollCd());
+    assertEquals("MATH      3B -1", edp.getCourseId());
+    assertEquals("0100", edp.getSection());
     assertEquals(142, edp.getEnrollment());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
+
 import java.util.List;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
@@ -32,5 +35,19 @@ public class ConvertedSectionTests {
     cs1.set_id(new ObjectId());
     ConvertedSection cs2 = (ConvertedSection) cs1.clone();
     assertEquals(cs1, cs2);
+  }
+
+  @Test
+  public void test_EnrollmentDataPoint() throws JsonProcessingException {
+    List<ConvertedSection> cs =
+        mapper.readValue(
+            CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH3B,
+            new TypeReference<List<ConvertedSection>>() {});
+
+    ConvertedSection cs1 = cs.get(0);
+    EnrollmentDataPoint edp = cs1.getEnrollmentDataPoint();
+    assertEquals("20211", edp.getYyyyq());
+    assertEquals("10001", edp.getEnrollCd());
+    assertEquals(10, edp.getEnrollment());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -10,6 +10,7 @@ import edu.ucsb.cs156.courses.entities.UCSBSubject;
 import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
+import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,8 @@ public class UpdateCourseDataJobFactoryTests {
   @Autowired UpdateCourseDataJobFactory factory;
 
   @MockBean EnrollmentDataPointRepository enrollmentDataPointRepository;
+
+  @MockBean UCSBAPIQuarterService ucsbapiQuarterService;
 
   @Test
   void test_createForSubjectAndQuarter() {

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.Update;
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
@@ -85,6 +86,8 @@ public class UpdateCourseDataJobTests {
     when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A")))
         .thenReturn(result);
 
+    when(ucsbapiQuarterService.isQuarterInRegistrationPass(anyString())).thenReturn(false);
+
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
     Update update = new Update(null, "CMPSC", "20211", 14, 0, 0, someTime);
     when(updateCollection.save(any())).thenReturn(update);
@@ -148,6 +151,7 @@ public class UpdateCourseDataJobTests {
     when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
             eq(section1.getCourseInfo().getQuarter()), eq(section1.getSection().getEnrollCode())))
         .thenReturn(emptyOptional);
+    when(ucsbapiQuarterService.isQuarterInRegistrationPass(anyString())).thenReturn(false);
 
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
     Update update = new Update(null, "MATH", "20211", 2, 1, 0, someTime);
@@ -205,6 +209,7 @@ public class UpdateCourseDataJobTests {
     when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
             eq(section0.getCourseInfo().getQuarter()), eq(section0.getSection().getEnrollCode())))
         .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+    when(ucsbapiQuarterService.isQuarterInRegistrationPass(anyString())).thenReturn(false);
 
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
     Update update = new Update(null, "MATH", "20211", 0, 0, 1, someTime);
@@ -267,6 +272,7 @@ public class UpdateCourseDataJobTests {
         .thenReturn(listWithUpdatedSection);
     when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
         .thenReturn(section0Optional);
+    when(ucsbapiQuarterService.isQuarterInRegistrationPass(anyString())).thenReturn(false);
 
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
     Update update = new Update(null, "MATH", "20211", 0, 1, 1, someTime);
@@ -335,10 +341,14 @@ public class UpdateCourseDataJobTests {
         .thenReturn(listWithUpdatedSection);
     when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
         .thenReturn(section0Optional);
+    when(ucsbapiQuarterService.isQuarterInRegistrationPass(eq("20211"))).thenReturn(true);
 
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
     Update update = new Update(null, "MATH", "20211", 0, 1, 1, someTime);
     when(updateCollection.save(any())).thenReturn(update);
+
+    EnrollmentDataPoint edp = updatedSection.getEnrollmentDataPoint();
+    when(enrollmentDataPointRepository.save(eq(edp))).thenReturn(edp);
 
     // Act
     var job =
@@ -370,6 +380,7 @@ public class UpdateCourseDataJobTests {
     verify(convertedSectionCollection, times(1))
         .findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
     verify(convertedSectionCollection, times(1)).save(updatedSection);
+    verify(enrollmentDataPointRepository, times(1)).save(eq(edp));
   }
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -14,6 +14,7 @@ import edu.ucsb.cs156.courses.documents.Update;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
+import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import java.time.LocalDateTime;
@@ -37,6 +38,8 @@ public class UpdateCourseDataJobTests {
 
   @Mock EnrollmentDataPointRepository enrollmentDataPointRepository;
 
+  @Mock UCSBAPIQuarterService ucsbapiQuarterService;
+
   Job jobStarted = Job.builder().build();
   JobContext ctx = new JobContext(null, jobStarted);
 
@@ -54,6 +57,7 @@ public class UpdateCourseDataJobTests {
                 .isStaleService(isStaleService)
                 .ifStale(false)
                 .enrollmentDataPointRepository(enrollmentDataPointRepository)
+                .ucsbapiQuarterService(ucsbapiQuarterService)
                 .build());
     doNothing().when(job).updateCourses(any(), any(), any());
 
@@ -96,7 +100,8 @@ public class UpdateCourseDataJobTests {
             updateCollection,
             isStaleService,
             false,
-            enrollmentDataPointRepository);
+            enrollmentDataPointRepository,
+            ucsbapiQuarterService);
     job.accept(ctx);
 
     // Assert
@@ -159,7 +164,8 @@ public class UpdateCourseDataJobTests {
             updateCollection,
             isStaleService,
             false,
-            enrollmentDataPointRepository);
+            enrollmentDataPointRepository,
+            ucsbapiQuarterService);
     job.accept(ctx);
 
     // Assert
@@ -215,7 +221,8 @@ public class UpdateCourseDataJobTests {
             updateCollection,
             isStaleService,
             false,
-            enrollmentDataPointRepository);
+            enrollmentDataPointRepository,
+            ucsbapiQuarterService);
     job.accept(ctx);
 
     // Assert
@@ -276,7 +283,8 @@ public class UpdateCourseDataJobTests {
             updateCollection,
             isStaleService,
             false,
-            enrollmentDataPointRepository);
+            enrollmentDataPointRepository,
+            ucsbapiQuarterService);
     job.accept(ctx);
 
     // Assert
@@ -343,7 +351,8 @@ public class UpdateCourseDataJobTests {
             updateCollection,
             isStaleService,
             true,
-            enrollmentDataPointRepository);
+            enrollmentDataPointRepository,
+            ucsbapiQuarterService);
     job.accept(ctx);
 
     // Assert
@@ -381,7 +390,8 @@ public class UpdateCourseDataJobTests {
             updateCollection,
             isStaleService,
             true,
-            enrollmentDataPointRepository);
+            enrollmentDataPointRepository,
+            ucsbapiQuarterService);
     job.accept(ctx);
   }
 }


### PR DESCRIPTION
Closes #173 

In this PR, we modify the UpdateCourseDataJob to collect enrollment data for courses that are inside an enrollment pass.

# To Test

On H2 or using `dokku postgres:connect courses-qa-db` check the contents of the enrollmentdatapoint table:

```
select * from enrollmentdatapoint;
```

Then, run the Update Course Data job for some subject area.  You may need to turn off the "if stale" flag so that you get an update.

You should see updated data in the table.