### PR TITLE
pc - bump node to 20.17.0 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v16.20.0</nodeVersion>
+                                    <nodeVersion>v20.17.0</nodeVersion>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
Not sure how this got missed the first time around, but the node version should have been updated to 20.17.0 in pom.xml at the same time it was updated everywhere else.

This PR fixes that oversight.

