### PR TITLE
pc - fix bug on job for updating courses by quarter

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -131,7 +131,7 @@ public class JobsController extends ApiController {
           @RequestParam(defaultValue = "true")
           Boolean ifStale) {
 
-    var job = updateCourseDataJobFactory.createForQuarter(quarterYYYYQ);
+    var job = updateCourseDataJobFactory.createForQuarter(quarterYYYYQ, ifStale);
 
     return jobService.runAsJob(job);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -161,7 +161,8 @@ public class JobsController extends ApiController {
           Boolean ifStale) {
 
     var job =
-        updateCourseDataJobFactory.createForQuarterRange(start_quarterYYYYQ, end_quarterYYYYQ);
+        updateCourseDataJobFactory.createForQuarterRange(
+            start_quarterYYYYQ, end_quarterYYYYQ, ifStale);
 
     return jobService.runAsJob(job);
   }
@@ -187,7 +188,7 @@ public class JobsController extends ApiController {
 
     var job =
         updateCourseDataJobFactory.createForSubjectAndQuarterRange(
-            subjectArea, start_quarterYYYYQ, end_quarterYYYYQ);
+            subjectArea, start_quarterYYYYQ, end_quarterYYYYQ, ifStale);
 
     return jobService.runAsJob(job);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/ScheduledJobs.java
@@ -43,7 +43,7 @@ public class ScheduledJobs {
     String currentQuarterYYYYQ = ucsbAPIQuarterService.getCurrentQuarterYYYYQ();
 
     JobContextConsumer updateCourseDataJob =
-        updateCourseDataJobFactory.createForQuarterRange(currentQuarterYYYYQ, endQtrYYYYQ);
+        updateCourseDataJobFactory.createForQuarterRange(currentQuarterYYYYQ, endQtrYYYYQ, true);
     jobService.runAsJob(updateCourseDataJob);
 
     log.info(

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -31,20 +31,6 @@ public class UpdateCourseDataJobFactory {
 
   @Autowired private UCSBAPIQuarterService ucsbapiQuarterService;
 
-  public UpdateCourseDataJob createForSubjectAndQuarter(String subjectArea, String quarterYYYYQ) {
-    return new UpdateCourseDataJob(
-        quarterYYYYQ,
-        quarterYYYYQ,
-        List.of(subjectArea),
-        curriculumService,
-        convertedSectionCollection,
-        updateCollection,
-        isStaleService,
-        false,
-        enrollmentDataPointRepository,
-        ucsbapiQuarterService);
-  }
-
   public UpdateCourseDataJob createForSubjectAndQuarterAndIfStale(
       String subjectArea, String quarterYYYYQ, boolean ifStale) {
     return new UpdateCourseDataJob(
@@ -61,7 +47,7 @@ public class UpdateCourseDataJobFactory {
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterRange(
-      String subjectArea, String start_quarterYYYYQ, String end_quarterYYYYQ) {
+      String subjectArea, String start_quarterYYYYQ, String end_quarterYYYYQ, boolean ifStale) {
     return new UpdateCourseDataJob(
         start_quarterYYYYQ,
         end_quarterYYYYQ,
@@ -70,7 +56,7 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        true,
+        ifStale,
         enrollmentDataPointRepository,
         ucsbapiQuarterService);
   }
@@ -99,7 +85,7 @@ public class UpdateCourseDataJobFactory {
   }
 
   public UpdateCourseDataJob createForQuarterRange(
-      String start_quarterYYYYQ, String end_quarterYYYYQ) {
+      String start_quarterYYYYQ, String end_quarterYYYYQ, boolean ifStale) {
     return new UpdateCourseDataJob(
         start_quarterYYYYQ,
         end_quarterYYYYQ,
@@ -108,7 +94,7 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        true,
+        ifStale,
         enrollmentDataPointRepository,
         ucsbapiQuarterService);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -84,7 +84,7 @@ public class UpdateCourseDataJobFactory {
     return subjectCodes;
   }
 
-  public UpdateCourseDataJob createForQuarter(String quarterYYYYQ) {
+  public UpdateCourseDataJob createForQuarter(String quarterYYYYQ, boolean ifStale) {
     return new UpdateCourseDataJob(
         quarterYYYYQ,
         quarterYYYYQ,
@@ -93,7 +93,7 @@ public class UpdateCourseDataJobFactory {
         convertedSectionCollection,
         updateCollection,
         isStaleService,
-        true,
+        ifStale,
         enrollmentDataPointRepository,
         ucsbapiQuarterService);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/startup/CoursesStartup.java
+++ b/src/main/java/edu/ucsb/cs156/courses/startup/CoursesStartup.java
@@ -48,7 +48,7 @@ public class CoursesStartup {
 
     JobContextConsumer updateCourseDataJob =
         updateCourseDataJobFactory.createForSubjectAndQuarterRange(
-            "CMPSC", startQtrYYYYQ, endQtrYYYYQ);
+            "CMPSC", startQtrYYYYQ, endQtrYYYYQ, true);
     jobService.runAsJob(updateCourseDataJob);
 
     log.info(
@@ -66,7 +66,7 @@ public class CoursesStartup {
     // Launch course update job
 
     JobContextConsumer updateCourseDataJob =
-        updateCourseDataJobFactory.createForQuarterRange(startQtrYYYYQ, endQtrYYYYQ);
+        updateCourseDataJobFactory.createForQuarterRange(startQtrYYYYQ, endQtrYYYYQ, true);
     jobService.runAsJob(updateCourseDataJob);
 
     log.info(

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -38,18 +38,6 @@ public class UpdateCourseDataJobFactoryTests {
   @MockBean UCSBAPIQuarterService ucsbapiQuarterService;
 
   @Test
-  void test_createForSubjectAndQuarter() {
-
-    // Act
-    UpdateCourseDataJob job = factory.createForSubjectAndQuarter("CMPSC", "20211");
-
-    // Assert
-    assertEquals(List.of("CMPSC"), job.getSubjects());
-    assertEquals("20211", job.getStart_quarterYYYYQ());
-    assertEquals("20211", job.getEnd_quarterYYYYQ());
-  }
-
-  @Test
   void test_createForSubjectAndQuarterAndIfStale() {
 
     // Act
@@ -66,7 +54,8 @@ public class UpdateCourseDataJobFactoryTests {
   void test_createForSubjectAndQuarterRange() {
 
     // Act
-    UpdateCourseDataJob job = factory.createForSubjectAndQuarterRange("CMPSC", "20211", "20213");
+    UpdateCourseDataJob job =
+        factory.createForSubjectAndQuarterRange("CMPSC", "20211", "20213", true);
 
     // Assert
     assertEquals(List.of("CMPSC"), job.getSubjects());
@@ -109,7 +98,7 @@ public class UpdateCourseDataJobFactoryTests {
 
     when(ucsbSubjectRepository.findAll()).thenReturn(subjects);
 
-    UpdateCourseDataJob job = factory.createForQuarterRange("20221", "20222");
+    UpdateCourseDataJob job = factory.createForQuarterRange("20221", "20222", false);
 
     // Assert
     assertEquals("20221", job.getStart_quarterYYYYQ());

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -86,7 +86,7 @@ public class UpdateCourseDataJobFactoryTests {
 
     when(ucsbSubjectRepository.findAll()).thenReturn(subjects);
 
-    UpdateCourseDataJob job = factory.createForQuarter("20211");
+    UpdateCourseDataJob job = factory.createForQuarter("20211", false);
 
     // Assert
 


### PR DESCRIPTION
# Description of bug

Steps to reproduce:
* Launch this job for any quarter, but with ifStale unchecked
  <img width="598" alt="image" src="https://github.com/user-attachments/assets/df631b2c-a88a-43d6-9311-516b84d4510b" />

* Expected: The job will update all subject areas for that quarter.
* Observed: The job has the ifStale flag hardcoded as true, so the job doesn't update subject areas unless they are stale

