### PR TITLE
pc - add swagger endpoint to get CSV file for enrollmentdata for a quarter

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/EnrollmentController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/EnrollmentController.java
@@ -3,35 +3,29 @@ package edu.ucsb.cs156.courses.controllers;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;
 import com.opencsv.exceptions.CsvDataTypeMismatchException;
 import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
-
 import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
 import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
-
-
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Streamable;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @Slf4j
@@ -39,40 +33,59 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 @RequestMapping("/api/enrollment")
 @RestController
 public class EnrollmentController extends ApiController {
-  @Autowired
-  EnrollmentDataPointRepository enrollmentDataPointRepository;
 
-  @Operation(summary = "Download CSV File", description = "Returns a CSV file as a response", responses = {
-      @ApiResponse(responseCode = "200", description = "CSV file", content = @Content(mediaType = "text/csv", schema = @Schema(type = "string", format = "binary"))),
-      @ApiResponse(responseCode = "500", description = "Internal Server Error")
-  })
+  @Autowired EnrollmentDataPointRepository enrollmentDataPointRepository;
+
+  @Operation(
+      summary = "Download CSV File",
+      description = "Returns a CSV file as a response",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "CSV file",
+            content =
+                @Content(
+                    mediaType = "text/csv",
+                    schema = @Schema(type = "string", format = "binary"))),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+      })
   @GetMapping(value = "/csv/quarter", produces = "text/csv")
   public ResponseEntity<StreamingResponseBody> csvForQuarter(
-      @Parameter(name = "yyyyq", description = "quarter in yyyyq format", example = "20252") @RequestParam String yyyyq)
-      throws Exception {
-    StreamingResponseBody stream = outputStream -> {
-      Iterable<EnrollmentDataPoint> iterable = enrollmentDataPointRepository.findByYyyyq(yyyyq);
-      List<EnrollmentDataPoint> list = Streamable.of(iterable).toList();
+      @Parameter(name = "yyyyq", description = "quarter in yyyyq format", example = "20252")
+          @RequestParam
+          String yyyyq,
+      @Parameter(
+              name = "testException",
+              description = "test exception",
+              example = "CsvDataTypeMismatchException")
+          @RequestParam(required = false, defaultValue = "")
+          String testException)
+      throws Exception, IOException {
+    StreamingResponseBody stream =
+        (outputStream) -> {
+          Iterable<EnrollmentDataPoint> iterable = enrollmentDataPointRepository.findByYyyyq(yyyyq);
+          List<EnrollmentDataPoint> list = Streamable.of(iterable).toList();
 
-      try (Writer writer = new OutputStreamWriter(outputStream,
-          StandardCharsets.UTF_8)) {
-        try {
-          new StatefulBeanToCsvBuilder<EnrollmentDataPoint>(writer)
-              .build().write(list);
-        } catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
-          log.error("Error writing CSV file", e);
-          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-      }
-    };
+          try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+            try {
+              if (testException.equals("CsvDataTypeMismatchException")) {
+                throw new CsvDataTypeMismatchException("test exception");
+              }
+              new StatefulBeanToCsvBuilder<EnrollmentDataPoint>(writer).build().write(list);
+            } catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
+              log.error("Error writing CSV file", e);
+              throw new IOException("Error writing CSV file: " + e.getMessage());
+            }
+          }
+        };
 
     return ResponseEntity.ok()
         .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
-        .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=enrollment_%s.csv", yyyyq))
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            String.format("attachment;filename=enrollment_%s.csv", yyyyq))
         .header(HttpHeaders.CONTENT_TYPE, "text/csv; charset=UTF-8")
-        .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
-            HttpHeaders.CONTENT_DISPOSITION)
+        .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION)
         .body(stream);
   }
-
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/EnrollmentController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/EnrollmentController.java
@@ -1,0 +1,78 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import com.opencsv.exceptions.CsvDataTypeMismatchException;
+import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
+
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
+import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Streamable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+@Slf4j
+@Tag(name = "API for enrollment data")
+@RequestMapping("/api/enrollment")
+@RestController
+public class EnrollmentController extends ApiController {
+  @Autowired
+  EnrollmentDataPointRepository enrollmentDataPointRepository;
+
+  @Operation(summary = "Download CSV File", description = "Returns a CSV file as a response", responses = {
+      @ApiResponse(responseCode = "200", description = "CSV file", content = @Content(mediaType = "text/csv", schema = @Schema(type = "string", format = "binary"))),
+      @ApiResponse(responseCode = "500", description = "Internal Server Error")
+  })
+  @GetMapping(value = "/csv/quarter", produces = "text/csv")
+  public ResponseEntity<StreamingResponseBody> csvForQuarter(
+      @Parameter(name = "yyyyq", description = "quarter in yyyyq format", example = "20252") @RequestParam String yyyyq)
+      throws Exception {
+    StreamingResponseBody stream = outputStream -> {
+      Iterable<EnrollmentDataPoint> iterable = enrollmentDataPointRepository.findByYyyyq(yyyyq);
+      List<EnrollmentDataPoint> list = Streamable.of(iterable).toList();
+
+      try (Writer writer = new OutputStreamWriter(outputStream,
+          StandardCharsets.UTF_8)) {
+        try {
+          new StatefulBeanToCsvBuilder<EnrollmentDataPoint>(writer)
+              .build().write(list);
+        } catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
+          log.error("Error writing CSV file", e);
+          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+      }
+    };
+
+    return ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+        .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=enrollment_%s.csv", yyyyq))
+        .header(HttpHeaders.CONTENT_TYPE, "text/csv; charset=UTF-8")
+        .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+            HttpHeaders.CONTENT_DISPOSITION)
+        .body(stream);
+  }
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EnrollmentDataPointRepository extends CrudRepository<EnrollmentDataPoint, Long> {
-    Iterable<EnrollmentDataPoint> findByYyyyq(String yyyyq);
+  Iterable<EnrollmentDataPoint> findByYyyyq(String yyyyq);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/EnrollmentDataPointRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EnrollmentDataPointRepository extends CrudRepository<EnrollmentDataPoint, Long> {}
+public interface EnrollmentDataPointRepository extends CrudRepository<EnrollmentDataPoint, Long> {
+    Iterable<EnrollmentDataPoint> findByYyyyq(String yyyyq);
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/EnrollmentControllerExceptionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/EnrollmentControllerExceptionTests.java
@@ -1,0 +1,61 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
+import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
+import edu.ucsb.cs156.courses.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = {EnrollmentController.class})
+@Import(TestConfig.class)
+@AutoConfigureDataJpa
+public class EnrollmentControllerExceptionTests extends ControllerTestCase {
+
+  @MockBean EnrollmentDataPointRepository enrollmentDataPointRepository;
+
+  @Test
+  public void test_exception() throws Exception {
+
+    // arrange
+
+    String yyyyq = "20252";
+    EnrollmentDataPoint dataPoint =
+        EnrollmentDataPoint.builder()
+            .id(1L)
+            .yyyyq(yyyyq)
+            .courseId("CMPSC 156")
+            .dateCreated(LocalDateTime.parse("2022-03-05T15:50:10"))
+            .enrollment(96)
+            .enrollCd("12345")
+            .section("0100")
+            .build();
+    List<EnrollmentDataPoint> dataPoints = List.of(dataPoint);
+
+    when(enrollmentDataPointRepository.findByYyyyq(yyyyq)).thenReturn(dataPoints);
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                get(
+                    "/api/enrollment/csv/quarter?yyyyq=20252&testException=CsvDataTypeMismatchException"))
+            .andReturn();
+
+    // assert
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals("", actualResponse);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/EnrollmentControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/EnrollmentControllerTests.java
@@ -1,0 +1,79 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
+import edu.ucsb.cs156.courses.repositories.EnrollmentDataPointRepository;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+public class EnrollmentControllerTests {
+
+  @Mock
+  private EnrollmentDataPointRepository enrollmentDataPointRepository =
+      mock(EnrollmentDataPointRepository.class);
+
+  @InjectMocks private EnrollmentController enrollmentController;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testCsvForQuarter_success() throws Exception {
+    String yyyyq = "20252";
+    EnrollmentDataPoint dataPoint =
+        EnrollmentDataPoint.builder()
+            .id(1L)
+            .yyyyq(yyyyq)
+            .courseId("CMPSC 156")
+            .dateCreated(LocalDateTime.parse("2022-03-05T15:50:10"))
+            .enrollment(96)
+            .enrollCd("12345")
+            .section("0100")
+            .build();
+    List<EnrollmentDataPoint> dataPoints = List.of(dataPoint);
+
+    when(enrollmentDataPointRepository.findByYyyyq(yyyyq)).thenReturn(dataPoints);
+
+    ResponseEntity<StreamingResponseBody> response = enrollmentController.csvForQuarter(yyyyq, "");
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("text/csv;charset=UTF-8", response.getHeaders().getContentType().toString());
+    String expectedFilename = "enrollment_" + yyyyq + ".csv";
+    String expectedContentDisposition = "attachment;filename=" + expectedFilename;
+    String actualContentDisposition =
+        response.getHeaders().get(HttpHeaders.CONTENT_DISPOSITION).get(0);
+    assertEquals(expectedContentDisposition, actualContentDisposition);
+
+    StreamingResponseBody body = response.getBody();
+    assertNotNull(body);
+
+    OutputStream outputStream = new ByteArrayOutputStream();
+    body.writeTo(outputStream);
+    String csvOutput = outputStream.toString();
+
+    String expectedCSVOutput =
+        """
+                "COURSEID","DATECREATED","ENROLLCD","ENROLLMENT","ID","SECTION","YYYYQ"
+                "CMPSC 156","2022-03-05T15:50:10","12345","96","1","0100","20252"
+                """;
+
+    assertEquals(expectedCSVOutput, csvOutput);
+  }
+}


### PR DESCRIPTION
In this PR, we add a swagger endpoint to get CSV file for enrollmentdata for a quarter.

The quarter is specified in yyyyq format (e.g. 20252 for Spring 2025).

# Screenshot

The blue "Download" link on Swagger is where the file is retrieved from when available.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/586335bf-d678-42c8-91a5-d2f24e88817d" />
