### PR TITLE
pc - add csv download endpoint for course data by quarter

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -26,4 +26,7 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
       "{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
   List<ConvertedSection> findByQuarterRangeAndBuildingCode(
       String startQuarter, String endQuarter, String buildingCode);
+
+  @Query("{'courseInfo.quarter': { $eq: ?0 } }")
+  List<ConvertedSection> findByQuarter(String quarter);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CoursesCSVController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CoursesCSVController.java
@@ -31,8 +31,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @Slf4j
-@Tag(name = "API for enrollment data")
-@RequestMapping("/api/courses")
+@Tag(name = "API for course data as CSV downloads")
+@RequestMapping("/api/courses/csv")
 @RestController
 public class CoursesCSVController extends ApiController {
 
@@ -51,15 +51,15 @@ public class CoursesCSVController extends ApiController {
                     schema = @Schema(type = "string", format = "binary"))),
         @ApiResponse(responseCode = "500", description = "Internal Server Error")
       })
-  @GetMapping(value = "/csv/quarter", produces = "text/csv")
+  @GetMapping(value = "/quarter", produces = "text/csv")
   public ResponseEntity<StreamingResponseBody> csvForCourses(
       @Parameter(name = "yyyyq", description = "quarter in yyyyq format", example = "20252")
           @RequestParam
           String yyyyq,
       @Parameter(
               name = "testException",
-              description = "test exception",
-              example = "CsvDataTypeMismatchException")
+              description = "test exception (e.g. CsvDataTypeMismatchException)",
+              example = "")
           @RequestParam(required = false, defaultValue = "")
           String testException)
       throws Exception, IOException {

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/EnrollmentController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/EnrollmentController.java
@@ -56,8 +56,8 @@ public class EnrollmentController extends ApiController {
           String yyyyq,
       @Parameter(
               name = "testException",
-              description = "test exception",
-              example = "CsvDataTypeMismatchException")
+              description = "test exception (e.g. CsvDataTypeMismatchException)",
+              example = "")
           @RequestParam(required = false, defaultValue = "")
           String testException)
       throws Exception, IOException {

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
@@ -28,10 +28,7 @@ public class CourseInfo implements Cloneable {
     }
 
     List<String> gesAsListOfStrings =
-        generalEducation.stream()
-            .map(GeneralEducation::toString)
-            .map(String::trim)
-            .collect(Collectors.toList());
+        generalEducation.stream().map(GeneralEducation::toString).collect(Collectors.toList());
     return String.join(", ", gesAsListOfStrings);
   }
 

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.documents;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,6 +21,18 @@ public class CourseInfo implements Cloneable {
   private String title;
   private String description;
   private List<GeneralEducation> generalEducation;
+
+  public String ges() {
+    if (generalEducation == null) {
+      return "";
+    }
+    List<String> gesAsListOfStrings =
+        generalEducation.stream()
+            .map(GeneralEducation::getGeCode)
+            .map(String::trim)
+            .collect(Collectors.toList());
+    return String.join(", ", gesAsListOfStrings);
+  }
 
   public Object clone() throws CloneNotSupportedException {
     CourseInfo newCourseInfo = (CourseInfo) super.clone();

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
@@ -26,9 +26,10 @@ public class CourseInfo implements Cloneable {
     if (generalEducation == null) {
       return "";
     }
+
     List<String> gesAsListOfStrings =
         generalEducation.stream()
-            .map(GeneralEducation::getGeCode)
+            .map(GeneralEducation::toString)
             .map(String::trim)
             .collect(Collectors.toList());
     return String.join(", ", gesAsListOfStrings);

--- a/src/main/java/edu/ucsb/cs156/courses/documents/GeneralEducation.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/GeneralEducation.java
@@ -18,8 +18,8 @@ public class GeneralEducation {
       return "";
     }
     if (geCollege == null) {
-      return geCode;
+      return geCode.trim();
     }
-    return geCode + " (" + geCollege + ")";
+    return geCode.trim() + " (" + geCollege.trim() + ")";
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/GeneralEducation.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/GeneralEducation.java
@@ -12,4 +12,14 @@ import lombok.NoArgsConstructor;
 public class GeneralEducation {
   private String geCode;
   private String geCollege;
+
+  public String toString() {
+    if (geCode == null) {
+      return "";
+    }
+    if (geCollege == null) {
+      return geCode;
+    }
+    return geCode + " (" + geCollege + ")";
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.documents;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,16 @@ public class Section implements Cloneable {
 
   /** is course cancelled */
   private String courseCancelled;
+
+  public String status() {
+    if (courseCancelled != null && courseCancelled.equals("Y")) {
+      return "Cancelled";
+    }
+    if (classClosed != null && classClosed.equals("Y")) {
+      return "Closed";
+    }
+    return "";
+  }
 
   /**
    * Grading Options Code like Pass/No Pass (P/NP) Or Letter Grades (L).
@@ -69,6 +80,15 @@ public class Section implements Cloneable {
 
   /** List of {@link Instructor} objects for this course */
   private List<Instructor> instructors;
+
+  public String instructorList() {
+    if (instructors == null) {
+      return "";
+    }
+    List<String> listOfInstructorNames =
+        instructors.stream().map(Instructor::getInstructor).collect(Collectors.toList());
+    return String.join(", ", listOfInstructorNames);
+  }
 
   public Object clone() throws CloneNotSupportedException {
 

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
@@ -2,10 +2,14 @@ package edu.ucsb.cs156.courses.documents;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class Section implements Cloneable {
 

--- a/src/main/java/edu/ucsb/cs156/courses/models/SectionCSVLine.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SectionCSVLine.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.courses.models;
+
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SectionCSVLine {
+
+  private String quarter;
+  private String courseId;
+  private String section;
+  private String instructor;
+  private String enrolled;
+  private String maxEnroll;
+  private String status;
+  private String ges;
+
+  public static String intToStringWithDefault(Integer i) {
+    return i == null ? "0" : i.toString();
+  }
+
+  public static SectionCSVLine toSectionCSVLine(ConvertedSection cs) {
+    return SectionCSVLine.builder()
+        .quarter(cs.getCourseInfo().getQuarter())
+        .courseId(cs.getCourseInfo().getCourseId())
+        .section(cs.getSection().getSection())
+        .enrolled(intToStringWithDefault(cs.getSection().getEnrolledTotal()))
+        .maxEnroll(intToStringWithDefault(cs.getSection().getMaxEnroll()))
+        .instructor(cs.getSection().instructorList())
+        .status(cs.getSection().status())
+        .ges(cs.getCourseInfo().ges())
+        .build();
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerExceptionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerExceptionTests.java
@@ -1,0 +1,50 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.testconfig.TestConfig;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = {CoursesCSVController.class})
+@Import(TestConfig.class)
+@AutoConfigureDataJpa
+public class CoursesCSVControllerExceptionTests extends ControllerTestCase {
+
+  @MockBean ConvertedSectionCollection convertedSectionCollection;
+
+  @Test
+  public void test_exception() throws Exception {
+
+    // arrange
+
+    String yyyyq = "20252";
+
+    List<ConvertedSection> emptyList = List.of();
+
+    when(convertedSectionCollection.findByQuarter(yyyyq)).thenReturn(emptyList);
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                get(
+                    "/api/courses/csv/quarter?yyyyq=20252&testException=CsvDataTypeMismatchException"))
+            .andReturn();
+
+    // assert
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals("", actualResponse);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerTests.java
@@ -1,0 +1,144 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.GeneralEducation;
+import edu.ucsb.cs156.courses.documents.Instructor;
+import edu.ucsb.cs156.courses.documents.Section;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+public class CoursesCSVControllerTests {
+
+  @Mock
+  private ConvertedSectionCollection convertedSectionCollection =
+      mock(ConvertedSectionCollection.class);
+
+  @InjectMocks private CoursesCSVController coursesCSVController;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testCsvForQuarter_success() throws Exception {
+    String yyyyq = "20252";
+
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter(yyyyq)
+            .courseId("CMPSC    8 -1")
+            .title("INTRO TO COMP SCI")
+            .generalEducation(
+                List.of(
+                    GeneralEducation.builder().geCode("C").build(),
+                    GeneralEducation.builder().geCode("QNT").build()))
+            .build();
+
+    Section section0100 =
+        Section.builder()
+            .section("0100")
+            .enrolledTotal(55)
+            .maxEnroll(150)
+            .courseCancelled("")
+            .classClosed("")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0101 =
+        Section.builder()
+            .section("0101")
+            .enrolledTotal(30)
+            .maxEnroll(30)
+            .courseCancelled("")
+            .classClosed("")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0102 =
+        Section.builder()
+            .section("0102")
+            .enrolledTotal(25)
+            .maxEnroll(30)
+            .courseCancelled("")
+            .classClosed("Y")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0103 =
+        Section.builder()
+            .section("0103")
+            .enrolledTotal(0)
+            .maxEnroll(30)
+            .courseCancelled("")
+            .classClosed("Y")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0104 =
+        Section.builder()
+            .section("0104")
+            .enrolledTotal(0)
+            .maxEnroll(30)
+            .courseCancelled("T")
+            .classClosed("")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Stream<Section> sections =
+        Stream.of(section0100, section0101, section0102, section0103, section0104);
+    List<ConvertedSection> dataPoints =
+        sections
+            .map(section -> ConvertedSection.builder().courseInfo(info).section(section).build())
+            .toList();
+
+    when(convertedSectionCollection.findByQuarter(yyyyq)).thenReturn(dataPoints);
+
+    ResponseEntity<StreamingResponseBody> response = coursesCSVController.csvForCourses(yyyyq, "");
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("text/csv;charset=UTF-8", response.getHeaders().getContentType().toString());
+    String expectedFilename = "courses_" + yyyyq + ".csv";
+    String expectedContentDisposition = "attachment;filename=" + expectedFilename;
+    String actualContentDisposition =
+        response.getHeaders().get(HttpHeaders.CONTENT_DISPOSITION).get(0);
+    assertEquals(expectedContentDisposition, actualContentDisposition);
+
+    StreamingResponseBody body = response.getBody();
+    assertNotNull(body);
+
+    OutputStream outputStream = new ByteArrayOutputStream();
+    body.writeTo(outputStream);
+    String csvOutput = outputStream.toString();
+
+    String expectedCSVOutput =
+        """
+        "COURSEID","ENROLLED","GES","INSTRUCTOR","MAXENROLL","QUARTER","SECTION","STATUS"
+        "CMPSC    8 -1","55","C, QNT","MIRZA D","150","20252","0100",""
+        "CMPSC    8 -1","30","C, QNT","MIRZA D","30","20252","0101",""
+        "CMPSC    8 -1","25","C, QNT","MIRZA D","30","20252","0102","Closed"
+        "CMPSC    8 -1","0","C, QNT","MIRZA D","30","20252","0103","Closed"
+        "CMPSC    8 -1","0","C, QNT","MIRZA D","30","20252","0104",""
+        """;
+
+    assertEquals(expectedCSVOutput, csvOutput);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerTests.java
@@ -49,8 +49,8 @@ public class CoursesCSVControllerTests {
             .title("INTRO TO COMP SCI")
             .generalEducation(
                 List.of(
-                    GeneralEducation.builder().geCode("C").build(),
-                    GeneralEducation.builder().geCode("QNT").build()))
+                    GeneralEducation.builder().geCode("C").geCollege("L&S").build(),
+                    GeneralEducation.builder().geCode("QNT").geCollege("L&S").build()))
             .build();
 
     Section section0100 =
@@ -132,11 +132,11 @@ public class CoursesCSVControllerTests {
     String expectedCSVOutput =
         """
         "COURSEID","ENROLLED","GES","INSTRUCTOR","MAXENROLL","QUARTER","SECTION","STATUS"
-        "CMPSC    8 -1","55","C, QNT","MIRZA D","150","20252","0100",""
-        "CMPSC    8 -1","30","C, QNT","MIRZA D","30","20252","0101",""
-        "CMPSC    8 -1","25","C, QNT","MIRZA D","30","20252","0102","Closed"
-        "CMPSC    8 -1","0","C, QNT","MIRZA D","30","20252","0103","Closed"
-        "CMPSC    8 -1","0","C, QNT","MIRZA D","30","20252","0104",""
+        "CMPSC    8 -1","55","C (L&S), QNT (L&S)","MIRZA D","150","20252","0100",""
+        "CMPSC    8 -1","30","C (L&S), QNT (L&S)","MIRZA D","30","20252","0101",""
+        "CMPSC    8 -1","25","C (L&S), QNT (L&S)","MIRZA D","30","20252","0102","Closed"
+        "CMPSC    8 -1","0","C (L&S), QNT (L&S)","MIRZA D","30","20252","0103","Closed"
+        "CMPSC    8 -1","0","C (L&S), QNT (L&S)","MIRZA D","30","20252","0104",""
         """;
 
     assertEquals(expectedCSVOutput, csvOutput);

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CourseInfoTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CourseInfoTests.java
@@ -32,16 +32,35 @@ public class CourseInfoTests {
   }
 
   @Test
-  public void test_ges() {
+  public void test_null_ges() {
     CourseInfo c = CourseInfo.builder().generalEducation(null).build();
     assertEquals("", c.ges());
+  }
+
+  @Test
+  public void test_empty_ges() {
+    CourseInfo c = CourseInfo.builder().generalEducation(List.of()).build();
+    assertEquals("", c.ges());
+  }
+
+  @Test
+  public void test_ges_with_college() {
 
     List<GeneralEducation> ges =
         List.of(
-            GeneralEducation.builder().geCode("C").build(),
-            GeneralEducation.builder().geCode("QNT").build());
+            GeneralEducation.builder().geCode("C").geCollege("L&S").build(),
+            GeneralEducation.builder().geCode("QNT").geCollege("L&S").build());
 
-    c = CourseInfo.builder().generalEducation(ges).build();
-    assertEquals("C, QNT", c.ges());
+    CourseInfo c = CourseInfo.builder().generalEducation(ges).build();
+    assertEquals("C (L&S), QNT (L&S)", c.ges());
+  }
+
+  @Test
+  public void test_ges_with_nulls() {
+    List<GeneralEducation> gesNullCases =
+        List.of(GeneralEducation.builder().geCode("C").build(), GeneralEducation.builder().build());
+
+    CourseInfo c = CourseInfo.builder().generalEducation(gesNullCases).build();
+    assertEquals("C, ", c.ges());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CourseInfoTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CourseInfoTests.java
@@ -30,4 +30,18 @@ public class CourseInfoTests {
     CourseInfo c2 = (CourseInfo) c1.clone();
     assertEquals(c1, c2);
   }
+
+  @Test
+  public void test_ges() {
+    CourseInfo c = CourseInfo.builder().generalEducation(null).build();
+    assertEquals("", c.ges());
+
+    List<GeneralEducation> ges =
+        List.of(
+            GeneralEducation.builder().geCode("C").build(),
+            GeneralEducation.builder().geCode("QNT").build());
+
+    c = CourseInfo.builder().generalEducation(ges).build();
+    assertEquals("C, QNT", c.ges());
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/GeneralEducationTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/GeneralEducationTests.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.courses.documents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@Import(ObjectMapper.class)
+@ContextConfiguration
+public class GeneralEducationTests {
+
+  @Autowired ObjectMapper mapper;
+
+  @Test
+  public void test_toString() {
+    GeneralEducation ge = GeneralEducation.builder().geCode("C ").geCollege("L&S ").build();
+    assertEquals("C (L&S)", ge.toString());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionTests.java
@@ -30,4 +30,36 @@ public class SectionTests {
     Section s2 = (Section) s1.clone();
     assertEquals(s1, s2);
   }
+
+  @Test
+  public void test_status() {
+    Section s = new Section();
+    s.setCourseCancelled("Y");
+    assertEquals("Cancelled", s.status());
+
+    s.setCourseCancelled("");
+    s.setClassClosed("Y");
+    assertEquals("Closed", s.status());
+
+    s.setCourseCancelled("");
+    s.setClassClosed("");
+    assertEquals("", s.status());
+
+    s.setCourseCancelled(null);
+    s.setClassClosed(null);
+    assertEquals("", s.status());
+  }
+
+  @Test
+  public void test_instructorlist() {
+
+    Section s = new Section();
+    assertEquals("", s.instructorList());
+    List<Instructor> instructors =
+        List.of(
+            Instructor.builder().instructor("CONRAD P T").build(),
+            Instructor.builder().instructor("WANG R K").build());
+    s.setInstructors(instructors);
+    assertEquals("CONRAD P T, WANG R K", s.instructorList());
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/models/SectionCSVLineTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/models/SectionCSVLineTests.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.courses.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SectionCSVLineTests {
+
+  @Test
+  public void test_intToStringWithDefault() throws Exception {
+    assertEquals("42", SectionCSVLine.intToStringWithDefault(Integer.valueOf(42)));
+    assertEquals("0", SectionCSVLine.intToStringWithDefault(null));
+  }
+}


### PR DESCRIPTION
In this PR, we add an endpoint /api/courses/csv/quarter that will download course information in a CSV format.

## Screenshot

<img width="990" alt="image" src="https://github.com/user-attachments/assets/c05ea401-8a4d-4541-97a1-f8920f0aa240" />
