### PR TITLE
pc - add rate limiting to course updates to avoid "spike delay" violation

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import edu.ucsb.cs156.courses.services.jobs.JobRateLimit;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @Slf4j
 public class UpdateCourseDataJob implements JobContextConsumer {
+
   private String start_quarterYYYYQ;
   private String end_quarterYYYYQ;
   private List<String> subjects;
@@ -33,9 +35,11 @@ public class UpdateCourseDataJob implements JobContextConsumer {
   private boolean ifStale;
   private EnrollmentDataPointRepository enrollmentDataPointRepository;
   private UCSBAPIQuarterService ucsbapiQuarterService;
+  private JobRateLimit jobRateLimit;
 
   @Override
   public void accept(JobContext ctx) throws Exception {
+
     ctx.log(
         String.format(
             "Updating courses from %s to %s for %d subjects",
@@ -50,6 +54,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
             continue;
           }
         }
+        jobRateLimit.sleep();
         updateCourses(ctx, quarterYYYYQ, subjectArea);
       }
     }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
 import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobRateLimit;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,8 @@ public class UpdateCourseDataJobFactory {
 
   @Autowired private UCSBAPIQuarterService ucsbapiQuarterService;
 
+  @Autowired private JobRateLimit jobRateLimit;
+
   public UpdateCourseDataJob createForSubjectAndQuarterAndIfStale(
       String subjectArea, String quarterYYYYQ, boolean ifStale) {
     return new UpdateCourseDataJob(
@@ -43,7 +46,8 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         ifStale,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService);
+        ucsbapiQuarterService,
+        jobRateLimit);
   }
 
   public UpdateCourseDataJob createForSubjectAndQuarterRange(
@@ -58,7 +62,8 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         ifStale,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService);
+        ucsbapiQuarterService,
+        jobRateLimit);
   }
 
   private List<String> getAllSubjectCodes() {
@@ -81,7 +86,8 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         ifStale,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService);
+        ucsbapiQuarterService,
+        jobRateLimit);
   }
 
   public UpdateCourseDataJob createForQuarterRange(
@@ -96,6 +102,7 @@ public class UpdateCourseDataJobFactory {
         isStaleService,
         ifStale,
         enrollmentDataPointRepository,
-        ucsbapiQuarterService);
+        ucsbapiQuarterService,
+        jobRateLimit);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobRateLimit.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobRateLimit.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@Service
+@Component
+@Slf4j
+public class JobRateLimit {
+
+  /**
+   * The delay in milliseconds to be used for rate limiting. This value is set from the application
+   * properties.
+   */
+  private int rateLimitDelayMs;
+
+  public JobRateLimit(@Value("${app.rateLimitDelayMs}") String rateLimitDelayMsString) {
+    try {
+      rateLimitDelayMs = Integer.parseInt(rateLimitDelayMsString);
+    } catch (NumberFormatException e) {
+      rateLimitDelayMs = 200;
+      log.warn("Invalid rate limit delay: " + rateLimitDelayMsString);
+      log.warn(String.format("Using default rate limit delay of %d ms", rateLimitDelayMs));
+    }
+  }
+
+  public void sleep() throws InterruptedException {
+    Thread.sleep(rateLimitDelayMs);
+  }
+
+  public int getRateLimitDelayMs() {
+    return rateLimitDelayMs;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ app.endQtrYYYYQ=${END_QTR:${env.END_QTR:20222}}
 
 app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}
 app.courseDataStaleThresholdMinutes=${COURSE_DATA_STALE_THRESHOLD_MINUTES:${env.COURSE_DATA_STALE_THRESHOLD_MINUTES:1440}}
+app.rateLimitDelayMs=${RATE_LIMIT_DELAY_MS:${env.RATE_LIMIT_DELAY_MS:200}}
 
 # 0 0 0 * * * = midnight every day
 # 0 0 * * * * = top of every hour

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -12,6 +12,7 @@ import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.courses.services.IsStaleService;
 import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobRateLimit;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,8 @@ public class UpdateCourseDataJobFactoryTests {
   @MockBean EnrollmentDataPointRepository enrollmentDataPointRepository;
 
   @MockBean UCSBAPIQuarterService ucsbapiQuarterService;
+
+  @MockBean JobRateLimit jobRateLimit;
 
   @Test
   void test_createForSubjectAndQuarterAndIfStale() {

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.courses.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -18,6 +19,7 @@ import edu.ucsb.cs156.courses.services.IsStaleService;
 import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobRateLimit;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,8 +28,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.TestPropertySource;
 
 @ExtendWith(MockitoExtension.class)
+@EnableConfigurationProperties(value = JobRateLimit.class)
+@TestPropertySource("classpath:application.properties")
 public class UpdateCourseDataJobTests {
   @Mock UCSBCurriculumService ucsbCurriculumService;
 
@@ -40,6 +46,8 @@ public class UpdateCourseDataJobTests {
   @Mock EnrollmentDataPointRepository enrollmentDataPointRepository;
 
   @Mock UCSBAPIQuarterService ucsbapiQuarterService;
+
+  @Mock JobRateLimit jobRateLimit;
 
   Job jobStarted = Job.builder().build();
   JobContext ctx = new JobContext(null, jobStarted);
@@ -59,6 +67,7 @@ public class UpdateCourseDataJobTests {
                 .ifStale(false)
                 .enrollmentDataPointRepository(enrollmentDataPointRepository)
                 .ucsbapiQuarterService(ucsbapiQuarterService)
+                .jobRateLimit(jobRateLimit)
                 .build());
     doNothing().when(job).updateCourses(any(), any(), any());
 
@@ -104,7 +113,8 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             false,
             enrollmentDataPointRepository,
-            ucsbapiQuarterService);
+            ucsbapiQuarterService,
+            jobRateLimit);
     job.accept(ctx);
 
     // Assert
@@ -169,7 +179,8 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             false,
             enrollmentDataPointRepository,
-            ucsbapiQuarterService);
+            ucsbapiQuarterService,
+            jobRateLimit);
     job.accept(ctx);
 
     // Assert
@@ -227,7 +238,8 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             false,
             enrollmentDataPointRepository,
-            ucsbapiQuarterService);
+            ucsbapiQuarterService,
+            jobRateLimit);
     job.accept(ctx);
 
     // Assert
@@ -290,7 +302,8 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             false,
             enrollmentDataPointRepository,
-            ucsbapiQuarterService);
+            ucsbapiQuarterService,
+            jobRateLimit);
     job.accept(ctx);
 
     // Assert
@@ -362,7 +375,8 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             true,
             enrollmentDataPointRepository,
-            ucsbapiQuarterService);
+            ucsbapiQuarterService,
+            jobRateLimit);
     job.accept(ctx);
 
     // Assert
@@ -402,7 +416,8 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             true,
             enrollmentDataPointRepository,
-            ucsbapiQuarterService);
+            ucsbapiQuarterService,
+            jobRateLimit);
     job.accept(ctx);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -80,6 +80,7 @@ public class UpdateCourseDataJobTests {
     verify(job).updateCourses(ctx, "20211", "MATH");
     verify(job).updateCourses(ctx, "20212", "MATH");
     verify(job).updateCourses(ctx, "20213", "MATH");
+    verify(jobRateLimit, atLeastOnce()).sleep();
   }
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobRateLimitBadPropertySourceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobRateLimitBadPropertySourceTests.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.courses.services.Jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.ucsb.cs156.courses.services.jobs.JobRateLimit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {JobRateLimit.class})
+@TestPropertySource(properties = "app.rateLimitDelayMs=notANumber")
+public class JobRateLimitBadPropertySourceTests {
+
+  @Autowired private JobRateLimit jobRateLimit;
+
+  // we expect that logger to be called with two warning messages
+  // "Invalid rate limit delay: notANumber"
+  // "Using default rate limit delay of 200 ms"
+
+  @Test
+  void test_rateLimitDelayMs() {
+    int rateLimitDelayMs = jobRateLimit.getRateLimitDelayMs();
+    assertEquals(
+        200, rateLimitDelayMs, "Rate limit default when bad value passed should be 200 ms");
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobRateLimitGoodPropertySourceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobRateLimitGoodPropertySourceTests.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.courses.services.Jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.ucsb.cs156.courses.services.jobs.JobRateLimit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {JobRateLimit.class})
+@TestPropertySource(properties = "app.rateLimitDelayMs=500")
+public class JobRateLimitGoodPropertySourceTests {
+
+  @Autowired private JobRateLimit jobRateLimit;
+
+  @Test
+  void test_rateLimitDelayMs() {
+    int rateLimitDelayMs = jobRateLimit.getRateLimitDelayMs();
+    assertEquals(500, rateLimitDelayMs, "Rate limit set from property source should be 500 ms");
+  }
+
+  @Test
+  void test_sleep() throws InterruptedException {
+    long startTime = System.currentTimeMillis();
+    jobRateLimit.sleep();
+    long endTime = System.currentTimeMillis();
+    long elapsedTime = endTime - startTime;
+    assertTrue(
+        elapsedTime >= jobRateLimit.getRateLimitDelayMs(),
+        "Sleep time should be at least the rate limit delay");
+  }
+}


### PR DESCRIPTION
In this PR we add a rate limiting delay to the UpdateCoursesJob.

This is a response to getting this error:

```
Updating courses from 20252 to 20254 for 146 subjects
500 Internal Server Error: "{"fault":{"faultstring":"Spike arrest violation. Allowed rate MessageRate{messagesPerPeriod=30, periodInMicroseconds=1000000, maxBurstMessageCount=3.0}","detail"
{"errorcode":"policies.ratelimit.SpikeArrestViolation"}}}"
```

The default is 200ms, but it can be overridden by setting the value of RATE_LIMIT_DELAY_MS.

I suggest monitoring how long the job takes to run, and using binary search to find an appropriate value that avoids the rate limiting error.

Closes #201 