### PR TITLE
pc - add backend endpoint that returns a list of primaries

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/PrimaryCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/PrimaryCollection.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.courses.collections;
+
+import edu.ucsb.cs156.courses.documents.Primary;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PrimaryCollection extends MongoRepository<Primary, ObjectId> {}

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.controllers;
 
+import edu.ucsb.cs156.courses.documents.Primary;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +24,9 @@ public class UCSBCurriculumController extends ApiController {
   @Autowired UserRepository userRepository;
   @Autowired UCSBCurriculumService ucsbCurriculumService;
 
-  @Operation(summary = "Get course data for a given quarter, department, and level")
+  @Operation(
+      summary =
+          "Get course data (in original UCSB API format) for a given quarter, department, and level")
   @GetMapping(value = "/basicsearch", produces = "application/json")
   public ResponseEntity<String> basicsearch(
       @RequestParam String qtr, @RequestParam String dept, @RequestParam String level)
@@ -32,6 +35,26 @@ public class UCSBCurriculumController extends ApiController {
     String body = ucsbCurriculumService.getJSON(dept, qtr, level);
 
     return ResponseEntity.ok().body(body);
+  }
+
+  /**
+   * Get primaries for a given quarter, department, and level. This endpoint returns a list of
+   * Primary objects.
+   *
+   * @param qtr the quarter in YYYYQ format
+   * @param dept the department code (e.g., "CS")
+   * @param level the course level (e.g., "UG" for undergraduate)
+   * @return a list of Primary objects
+   */
+  @Operation(summary = "Get primaries for a given quarter, department, and level")
+  @GetMapping(value = "/primaries", produces = "application/json")
+  public List<Primary> primaries(
+      @RequestParam String qtr, @RequestParam String dept, @RequestParam String level)
+      throws Exception {
+
+    List<Primary> primaries = ucsbCurriculumService.getPrimaries(dept, qtr, level);
+
+    return primaries;
   }
 
   // Backend for final exam info, similar to the above operation:

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -64,6 +65,87 @@ public class CoursePage {
             ConvertedSection.builder().courseInfo(courseInfo).section(section).build();
         result.add(cs);
       }
+    }
+    return result;
+  }
+
+  /**
+   * Look ahead to the next section if there is one
+   *
+   * @param sections List of sections
+   * @param sectionIndex the index of the current section
+   * @return the next section if it exists, otherwise null
+   */
+  public static Section nextSection(List<Section> sections, int sectionIndex) {
+    if (sectionIndex + 1 < sections.size()) {
+      return sections.get(sectionIndex + 1);
+    }
+    return null; // No more sections to look at
+  }
+
+  /**
+   * Given a Course, return a list of Primary objects.
+   *
+   * <p>The reason this is necessary is that the UCSB API returns a course with a list of sections.
+   * However, that list of sections may contain multiple primary sections, each with its own set of
+   * secondary sections.
+   *
+   * <p>This method processes the sections of a course to create a list of Primary objects, each
+   * representing a primary section and its associated secondary sections.
+   *
+   * @return a list of Primary objects
+   */
+  public static List<Primary> getListOfPrimaries(Course course) {
+    List<Primary> result = new ArrayList<>();
+    List<Section> classSections = course.getClassSections();
+
+    if (classSections.isEmpty()) {
+      return Collections.emptyList(); // No sections to process
+    }
+
+    Section firstSection = classSections.get(0);
+    if (!firstSection.isPrimary()) {
+      log.error("First section is not primary: {}", firstSection);
+      return Collections.emptyList(); // No sections to process
+    }
+
+    int sectionIndex = 0;
+    Section thisSection = classSections.get(sectionIndex);
+
+    while (thisSection != null) {
+      List<Section> secondaries = new ArrayList<>();
+      Section lookAhead = nextSection(classSections, sectionIndex);
+
+      while (lookAhead != null && !lookAhead.isPrimary()) {
+        secondaries.add(lookAhead);
+        sectionIndex++;
+        lookAhead = nextSection(classSections, sectionIndex);
+      }
+
+      Primary primary =
+          Primary.builder()
+              .quarter(course.getQuarter())
+              .courseId(course.getCourseId())
+              .title(course.getTitle())
+              .description(course.getDescription())
+              .primary(thisSection)
+              .secondaries(secondaries)
+              .generalEducation(course.getGeneralEducation())
+              .build();
+      result.add(primary);
+      thisSection = nextSection(classSections, sectionIndex);
+      sectionIndex++; // Move to the next section
+    }
+    return result;
+  }
+
+  /** Get a list of Primary objects from the CoursePage */
+  public List<Primary> getPrimaries() {
+    List<Primary> result = new ArrayList<>();
+
+    for (Course c : this.getClasses()) {
+      List<Primary> primaries = getListOfPrimaries(c);
+      result.addAll(primaries);
     }
     return result;
   }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Primary.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Primary.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.courses.documents;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,15 +13,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonIgnoreProperties(
-    ignoreUnknown = true,
-    value = {"contactHours"})
-@Document(collection = "courses")
-public class Course {
+@Document(collection = "primaries")
+public class Primary {
   private String quarter;
   private String courseId;
   private String title;
   private String description;
-  private List<Section> classSections;
+  private Section primary;
+  private List<Section> secondaries;
   private List<GeneralEducation> generalEducation;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -98,5 +99,15 @@ public class Section implements Cloneable {
 
     Section newSection = (Section) super.clone();
     return newSection;
+  }
+
+  /**
+   * Check if the section is a primary section (i.e. section number ends with "00").
+   *
+   * @return true if the section is a primary section, false otherwise
+   */
+  @JsonIgnore
+  public boolean isPrimary() {
+    return section != null && section.matches("\\d+00");
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.GERequirement;
+import edu.ucsb.cs156.courses.documents.Primary;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -101,6 +102,41 @@ public class UCSBCurriculumService {
     String json = getJSON(subjectArea, quarter, courseLevel);
     CoursePage coursePage = objectMapper.readValue(json, CoursePage.class);
     List<ConvertedSection> result = coursePage.convertedSections();
+    return result;
+  }
+
+  /**
+   * This method retrieves course information and reformats it so that each primary is a single
+   * object, that has a list of all of it's secondaries.
+   *
+   * <p>As a reminder, the UCSB course registration systems (GOLD, Blue, Star, etc.) treat all
+   * courses as "sections", even what we typically call "lectures". In the database, some courses
+   * have both primary and secondary sections. Primary sections have section numbers ending in 00
+   * (e.g. 100, 200, 300, up to 9900), while secondaries have numbers ending with 01, 02, 03, etc.
+   * and "belong" with a primary.
+   *
+   * <p>What we typically refer to as "lectures" are primary sections ending in 00 (e.g. 100, 200,
+   * 300). What we typically refer to as discussion sections are secondaries and end with 01, 02,
+   * 03, etc.
+   *
+   * <p>
+   *
+   * <p>The UCSB API <i>almost</i> does this, but not quite. It returns a list of all sections, but
+   * does not group them into primaries and secondaries. This method relies on the <code>
+   * getPrimaries</code> method of the <code>Page</code> class to reformat the data so that each
+   * primary section is a single object, with a list of all of its secondaries.
+   *
+   * @param subjectArea
+   * @param quarter
+   * @param courseLevel
+   * @return a list of Primaries
+   * @throws Exception
+   */
+  public List<Primary> getPrimaries(String subjectArea, String quarter, String courseLevel)
+      throws Exception {
+    String json = getJSON(subjectArea, quarter, courseLevel);
+    CoursePage coursePage = objectMapper.readValue(json, CoursePage.class);
+    List<Primary> result = coursePage.getPrimaries();
     return result;
   }
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -6,8 +6,12 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.documents.Primary;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import java.util.List;
@@ -112,5 +116,33 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
     // JSON representation of ["A1","A2"]
     assertEquals("[\"A1\",\"A2\"]", body);
   }
+
+  @Test
+  public void test_getPrimaries() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    String subjectArea = "MATH";
+    String quarter = "20222";
+    String level = "L";
+    String expectedCoursePageJSON = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+    CoursePage expectedCoursePage =
+        objectMapper.readValue(expectedCoursePageJSON, CoursePage.class);
+    List<Primary> expectedConvertedPrimaries = expectedCoursePage.getPrimaries();
+
+    when(ucsbCurriculumService.getPrimaries(subjectArea, quarter, level))
+        .thenReturn(expectedConvertedPrimaries);
+    MvcResult response =
+        mockMvc
+            .perform(
+                get("/api/public/primaries")
+                    .param("dept", subjectArea)
+                    .param("qtr", quarter)
+                    .param("level", level)
+                    .contentType("application/json"))
+            .andExpect(status().isOk())
+            .andExpect(content().json(objectMapper.writeValueAsString(expectedConvertedPrimaries)))
+            .andReturn();
+
+    String body = response.getResponse().getContentAsString();
+    assertEquals(objectMapper.writeValueAsString(expectedConvertedPrimaries), body);
+  }
 }
-;

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageFixtures.java
@@ -2,6 +2,125 @@ package edu.ucsb.cs156.courses.documents;
 
 public class CoursePageFixtures {
 
+  public static final String COURSE_PAGE_JSON_ERROR_NO_SECTIONS =
+      """
+                  {
+          "pageNumber": 1,
+          "pageSize": 10,
+          "total": 0,
+          "classes": [
+              {
+                  "quarter": "20222",
+                  "courseId": "MATH      3B ",
+                  "title": "CALC WITH APPLI 2",
+                  "contactHours": 30,
+                  "description": "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+                  "college": "L&S",
+                  "objLevelCode": "U",
+                  "subjectArea": "MATH    ",
+                  "unitsFixed": 4,
+                  "unitsVariableHigh": null,
+                  "unitsVariableLow": null,
+                  "delayedSectioning": null,
+                  "inProgressCourse": null,
+                  "gradingOption": null,
+                  "instructionType": "LEC",
+                  "onLineCourse": false,
+                  "deptCode": "MATH ",
+                  "generalEducation": [
+                      {
+                          "geCode": "C  ",
+                          "geCollege": "L&S "
+                      },
+                      {
+                          "geCode": "QNT",
+                          "geCollege": "L&S "
+                      }
+                  ],
+                  "classSections": []
+              }
+          ]
+      }
+      """;
+
+  public static final String COURSE_PAGE_JSON_ERROR_FIRST_SECTION_NOT_PRIMARY =
+      """
+                {
+          "pageNumber": 1,
+          "pageSize": 10,
+          "total": 0,
+          "classes": [
+              {
+                  "quarter": "20222",
+                  "courseId": "MATH      3B ",
+                  "title": "CALC WITH APPLI 2",
+                  "contactHours": 30,
+                  "description": "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+                  "college": "L&S",
+                  "objLevelCode": "U",
+                  "subjectArea": "MATH    ",
+                  "unitsFixed": 4,
+                  "unitsVariableHigh": null,
+                  "unitsVariableLow": null,
+                  "delayedSectioning": null,
+                  "inProgressCourse": null,
+                  "gradingOption": null,
+                  "instructionType": "LEC",
+                  "onLineCourse": false,
+                  "deptCode": "MATH ",
+                  "generalEducation": [
+                      {
+                          "geCode": "C  ",
+                          "geCollege": "L&S "
+                      },
+                      {
+                          "geCode": "QNT",
+                          "geCollege": "L&S "
+                      }
+                  ],
+                  "classSections": [
+                      {
+                          "enrollCode": "30403",
+                          "section": "0101",
+                          "session": null,
+                          "classClosed": null,
+                          "courseCancelled": null,
+                          "gradingOptionCode": null,
+                          "enrolledTotal": 23,
+                          "maxEnroll": 25,
+                          "secondaryStatus": null,
+                          "departmentApprovalRequired": false,
+                          "instructorApprovalRequired": false,
+                          "restrictionLevel": "K",
+                          "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                          "restrictionMajorPass": "1",
+                          "restrictionMinor": null,
+                          "restrictionMinorPass": null,
+                          "concurrentCourses": [],
+                          "timeLocations": [
+                              {
+                                  "room": "1231",
+                                  "building": "HSSB",
+                                  "roomCapacity": 26,
+                                  "days": " T     ",
+                                  "beginTime": "17:00",
+                                  "endTime": "17:50"
+                              }
+                          ],
+                          "instructors": [
+                              {
+                                  "instructor": "YOUNG C G",
+                                  "functionCode": "Teaching but not in charge"
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ]
+      }
+
+      """;
+
   public static final String COURSE_PAGE_JSON_MATH3B =
       """
              {
@@ -536,698 +655,698 @@ public class CoursePageFixtures {
 
   public static final String CONVERTED_SECTIONS_JSON_MATH3B =
       """
-             [ {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -1",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                   "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
-               },
-                 "section" : {
-                   "enrollCode" : "30395",
-                   "section" : "0100",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 142,
-                   "maxEnroll" : 150,
-                   "secondaryStatus" : "R",
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1001",
-                     "building" : "LSB",
-                     "roomCapacity" : "159",
-                     "days" : "M W F  ",
-                     "beginTime" : "11:00",
-                     "endTime" : "11:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "KUMAR S L",
-                     "functionCode" : "Teaching and in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -1",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+      [ {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -1",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+            "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
+        },
+          "section" : {
+            "enrollCode" : "30395",
+            "section" : "0100",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 142,
+            "maxEnroll" : 150,
+            "secondaryStatus" : "R",
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1001",
+              "building" : "LSB",
+              "roomCapacity" : "159",
+              "days" : "M W F  ",
+              "beginTime" : "11:00",
+              "endTime" : "11:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "KUMAR S L",
+              "functionCode" : "Teaching and in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -1",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
-                 },
-                 "section" : {
-                   "enrollCode" : "30403",
-                   "section" : "0101",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 23,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1231",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : " T     ",
-                     "beginTime" : "17:00",
-                     "endTime" : "17:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "YOUNG C G",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -1",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                 "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "30403",
+            "section" : "0101",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 23,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1231",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : " T     ",
+              "beginTime" : "17:00",
+              "endTime" : "17:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "YOUNG C G",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -1",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+          "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
-                 },
-                 "section" : {
-                   "enrollCode" : "30411",
-                   "section" : "0102",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 25,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1231",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : " T     ",
-                     "beginTime" : "18:00",
-                     "endTime" : "18:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "YOUNG C G",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -1",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
-                 },
-                 "section" : {
-                   "enrollCode" : "30429",
-                   "section" : "0103",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 23,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1207",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "   R   ",
-                     "beginTime" : "08:00",
-                     "endTime" : "08:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "FAGAN L M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -1",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
-
-
-                 },
-                 "section" : {
-                   "enrollCode" : "30437",
-                   "section" : "0104",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 24,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "2251",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "   R   ",
-                     "beginTime" : "17:00",
-                     "endTime" : "17:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "YOUNG C G",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -1",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "30411",
+            "section" : "0102",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 25,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1231",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : " T     ",
+              "beginTime" : "18:00",
+              "endTime" : "18:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "YOUNG C G",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -1",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
+          },
+          "section" : {
+            "enrollCode" : "30429",
+            "section" : "0103",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 23,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1207",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "   R   ",
+              "beginTime" : "08:00",
+              "endTime" : "08:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "FAGAN L M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -1",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
 
-                 },
-                 "section" : {
-                   "enrollCode" : "30445",
-                   "section" : "0105",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 24,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1214",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "   R   ",
-                     "beginTime" : "19:00",
-                     "endTime" : "19:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "YOUNG C G",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -1",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "30437",
+            "section" : "0104",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 24,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "2251",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "   R   ",
+              "beginTime" : "17:00",
+              "endTime" : "17:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "YOUNG C G",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -1",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
 
-                 },
-                 "section" : {
-                   "enrollCode" : "30452",
-                   "section" : "0106",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 23,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1215",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : " T     ",
-                     "beginTime" : "08:00",
-                     "endTime" : "08:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "FAGAN L M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -2",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "30445",
+            "section" : "0105",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 24,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1214",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "   R   ",
+              "beginTime" : "19:00",
+              "endTime" : "19:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "YOUNG C G",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -1",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
 
-                 },
-                 "section" : {
-                   "enrollCode" : "54692",
-                   "section" : "0200",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 41,
-                   "maxEnroll" : 150,
-                   "secondaryStatus" : "R",
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1001",
-                     "building" : "LSB",
-                     "roomCapacity" : "159",
-                     "days" : " T R   ",
-                     "beginTime" : "12:30",
-                     "endTime" : "13:45"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "PARK J",
-                     "functionCode" : "Teaching and in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -2",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "30452",
+            "section" : "0106",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 23,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1215",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : " T     ",
+              "beginTime" : "08:00",
+              "endTime" : "08:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "FAGAN L M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -2",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
 
-                 },
-                 "section" : {
-                   "enrollCode" : "54700",
-                   "section" : "0201",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 7,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1215",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "M      ",
-                     "beginTime" : "08:00",
-                     "endTime" : "08:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "PARKER M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -2",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "54692",
+            "section" : "0200",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 41,
+            "maxEnroll" : 150,
+            "secondaryStatus" : "R",
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1001",
+              "building" : "LSB",
+              "roomCapacity" : "159",
+              "days" : " T R   ",
+              "beginTime" : "12:30",
+              "endTime" : "13:45"
+            } ],
+            "instructors" : [ {
+              "instructor" : "PARK J",
+              "functionCode" : "Teaching and in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -2",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
 
-                 },
-                 "section" : {
-                   "enrollCode" : "54783",
-                   "section" : "0202",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 8,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1231",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "M      ",
-                     "beginTime" : "18:00",
-                     "endTime" : "18:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "PARKER M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -2",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "54700",
+            "section" : "0201",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 7,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1215",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "M      ",
+              "beginTime" : "08:00",
+              "endTime" : "08:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "PARKER M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -2",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
 
-                 },
-                 "section" : {
-                   "enrollCode" : "54791",
-                   "section" : "0203",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 19,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1237",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "M      ",
-                     "beginTime" : "17:00",
-                     "endTime" : "17:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "PARKER M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -2",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
+          },
+          "section" : {
+            "enrollCode" : "54783",
+            "section" : "0202",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 8,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1231",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "M      ",
+              "beginTime" : "18:00",
+              "endTime" : "18:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "PARKER M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -2",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
 
 
-                 },
-                 "section" : {
-                   "enrollCode" : "54809",
-                   "section" : "0204",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 1,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1228",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "M      ",
-                     "beginTime" : "18:00",
-                     "endTime" : "18:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "FAGAN L M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -2",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
-                 },
-                 "section" : {
-                   "enrollCode" : "54817",
-                   "section" : "0205",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 2,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1214",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "M      ",
-                     "beginTime" : "19:00",
-                     "endTime" : "19:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "PARKER M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               }, {
-                 "courseInfo" : {
-                   "quarter" : "20222",
-                   "courseId" : "MATH      3B -2",
-                   "title" : "CALC WITH APPLI 2",
-                   "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
-                    "generalEducation": [
-                       {
-                         "geCode": "C  ",
-                         "geCollege": "L&S "
-                       },
-                       {
-                         "geCode": "QNT",
-                         "geCollege": "L&S "
-                       }
-                     ]
-                 },
-                 "section" : {
-                   "enrollCode" : "54825",
-                   "section" : "0206",
-                   "session" : null,
-                   "classClosed" : null,
-                   "courseCancelled" : null,
-                   "gradingOptionCode" : null,
-                   "enrolledTotal" : 4,
-                   "maxEnroll" : 25,
-                   "secondaryStatus" : null,
-                   "departmentApprovalRequired" : false,
-                   "instructorApprovalRequired" : false,
-                   "restrictionLevel" : "K",
-                   "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
-                   "restrictionMajorPass" : "1",
-                   "restrictionMinor" : null,
-                   "restrictionMinorPass" : null,
-                   "concurrentCourses" : [ ],
-                   "timeLocations" : [ {
-                     "room" : "1236",
-                     "building" : "HSSB",
-                     "roomCapacity" : "26",
-                     "days" : "M      ",
-                     "beginTime" : "17:00",
-                     "endTime" : "17:50"
-                   } ],
-                   "instructors" : [ {
-                     "instructor" : "FAGAN L M",
-                     "functionCode" : "Teaching but not in charge"
-                   } ]
-                 }
-               } ]
-                 """;
+          },
+          "section" : {
+            "enrollCode" : "54791",
+            "section" : "0203",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 19,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1237",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "M      ",
+              "beginTime" : "17:00",
+              "endTime" : "17:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "PARKER M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -2",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
+
+
+          },
+          "section" : {
+            "enrollCode" : "54809",
+            "section" : "0204",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 1,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1228",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "M      ",
+              "beginTime" : "18:00",
+              "endTime" : "18:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "FAGAN L M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -2",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
+          },
+          "section" : {
+            "enrollCode" : "54817",
+            "section" : "0205",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 2,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1214",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "M      ",
+              "beginTime" : "19:00",
+              "endTime" : "19:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "PARKER M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        }, {
+          "courseInfo" : {
+            "quarter" : "20222",
+            "courseId" : "MATH      3B -2",
+            "title" : "CALC WITH APPLI 2",
+            "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+             "generalEducation": [
+                {
+                  "geCode": "C  ",
+                  "geCollege": "L&S "
+                },
+                {
+                  "geCode": "QNT",
+                  "geCollege": "L&S "
+                }
+              ]
+          },
+          "section" : {
+            "enrollCode" : "54825",
+            "section" : "0206",
+            "session" : null,
+            "classClosed" : null,
+            "courseCancelled" : null,
+            "gradingOptionCode" : null,
+            "enrolledTotal" : 4,
+            "maxEnroll" : 25,
+            "secondaryStatus" : null,
+            "departmentApprovalRequired" : false,
+            "instructorApprovalRequired" : false,
+            "restrictionLevel" : "K",
+            "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+            "restrictionMajorPass" : "1",
+            "restrictionMinor" : null,
+            "restrictionMinorPass" : null,
+            "concurrentCourses" : [ ],
+            "timeLocations" : [ {
+              "room" : "1236",
+              "building" : "HSSB",
+              "roomCapacity" : "26",
+              "days" : "M      ",
+              "beginTime" : "17:00",
+              "endTime" : "17:50"
+            } ],
+            "instructors" : [ {
+              "instructor" : "FAGAN L M",
+              "functionCode" : "Teaching but not in charge"
+            } ]
+          }
+        } ]
+          """;
 
   public static final String COURSE_PAGE_JSON =
       """

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
@@ -47,4 +47,61 @@ public class CoursePageTests {
     CoursePage cp = CoursePage.fromJSON("this is not valid JSON");
     assertNull(cp);
   }
+
+  @Test
+  public void nextSectionReturnsNextSection() throws JsonProcessingException {
+    CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
+    List<Section> sections = cp.getClasses().get(0).getClassSections();
+    Section nextSection = CoursePage.nextSection(sections, 0);
+    assertEquals("30403", nextSection.getEnrollCode());
+    Section lastSection = CoursePage.nextSection(sections, sections.size() - 1);
+    assertNull(lastSection); // No next section available
+  }
+
+  @Test
+  public void test_getPrimaries() throws JsonProcessingException {
+    CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
+    List<Primary> primaries = cp.getPrimaries();
+    assertEquals(2, primaries.size());
+  }
+
+  @Test
+  public void test_getPrimaries_error_no_sections() throws JsonProcessingException {
+    CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_ERROR_NO_SECTIONS);
+    List<Primary> primaries = cp.getPrimaries();
+    assertEquals(0, primaries.size());
+  }
+
+  @Test
+  public void test_getPrimaries_error_first_section_not_primary() throws JsonProcessingException {
+    CoursePage cp =
+        CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_ERROR_FIRST_SECTION_NOT_PRIMARY);
+    List<Primary> primaries = cp.getPrimaries();
+    assertEquals(0, primaries.size());
+  }
+
+  @Test
+  public void test_getListOfPrimaries() throws JsonProcessingException {
+    CoursePage coursePage = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
+    Course course = coursePage.getClasses().get(0); // Get the first course
+    List<Primary> primaries = CoursePage.getListOfPrimaries(course);
+    assertEquals(2, primaries.size());
+  }
+
+  @Test
+  public void test_getListOfPrimaries_FirstSectionNotPrimary() throws JsonProcessingException {
+    CoursePage coursePage =
+        CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_ERROR_FIRST_SECTION_NOT_PRIMARY);
+    Course course = coursePage.getClasses().get(0); // Get the first course
+    List<Primary> primaries = CoursePage.getListOfPrimaries(course);
+    assertEquals(0, primaries.size());
+  }
+
+  @Test
+  public void test_getListOfPrimaries_error_no_sections() throws JsonProcessingException {
+    Course course = new Course();
+    course.setClassSections(List.of()); // empty sections
+    List<Primary> primaries = CoursePage.getListOfPrimaries(course);
+    assertEquals(0, primaries.size());
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionTests.java
@@ -62,4 +62,17 @@ public class SectionTests {
     s.setInstructors(instructors);
     assertEquals("CONRAD P T, WANG R K", s.instructorList());
   }
+
+  @Test
+  public void test_isPrimary() {
+    Section s = new Section();
+    s.setSection("12300");
+    assertEquals(true, s.isPrimary());
+    s.setSection("12301");
+    assertEquals(false, s.isPrimary());
+    s.setSection("123");
+    assertEquals(false, s.isPrimary());
+    s.setSection(null);
+    assertEquals(false, s.isPrimary());
+  }
 }


### PR DESCRIPTION
Deployed at https://courses-qa.dokku-00.cs.ucsb.edu

This is a first step towards simplifying the structure of the frontend code for displaying courses.  The new TanStack react table has much nicer features for condensing rows that can work with the JSON without having to do the tricks we had to do before with flattening the sections (the "ConvertedSection" thing).

This should make things much easier; we can *almost* work with the JSON directly in the form in which it comes from the UCSB API.  We only have to make one small tweak, which is to separate out the individual primaries into separate objects.

# Screenshot

Link to Live API:  
[`GET /api/public/primaries`](https://courses-qa.dokku-00.cs.ucsb.edu/swagger-ui/index.html#/UCSBCurriculumController/primaries)
Get primaries for a given quarter, department, and level

<img width="510" height="369" alt="image" src="https://github.com/user-attachments/assets/05a822db-1abd-4e73-9989-80a91dcc5097" />


# Discussion

The user facing change is to simply add one new backend endpoint: `/api/public/primaries`.

The best way to understand this new endpoint is to compare it with the existing endpoint  endpoint `/api/public/basicsearch`    (the very first endpoint that we built the entire application around.). The endpoint  `/api/public/basicsearch` gives us the JSON from the UCSB API Curriculum service unmodified.   

The new endpoint `/api/public/primaries` is almost exactly the same, except in the way that it handles the case of multiple primary sections for a course (e.g. multiple lectures for MATH 3B, each of which have their own discussion sections, and are offered in the same quarter.) 

The existing UCSB API, and the endpoint `/api/public/basicsearch` will return a single course object for MATH 3B, and list all of the lecture and discussion sections together in a single list. 

The new endpoint will divide out each lecture (e.g. primary) into it's own object in the JSON, with a field for the primary, and field that is a list of the secondaries. 

The intent is to make it easier to build user interfaces that show/hide the secondaries.   In this past, this was done by flattening the JSON (the `ConvertedSection` code you find in the backend), and then regrouping it in the frontend.  *This is overly complex, not the best approach, and no longer necessary*.   

But getting away from this old approach is complex, so we are doing it in stages.  This is the first step: providing a more sane backend endpoint that we can build a new set of frontend components on top of.  Eventually, we'll completely switch over to the new components, and remove the code for converted sections, along with the convoluted frontend components that went along with it, replacing with this simpler approach.

# Test Plan

1. Go to swagger and do a search via  `/api/public/primaries` on a subject area, quarter and level that has multiple primaries for the same course (e.g. `MATH`).
2. Look at the JSON and see that it is structured properly, with one course object per lecture section, the x00 section associated with the key `primary` and the discussion sections in a list associated with the key `secondaries`.

