### PR TITLE
Jobs System Rework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
                         <param>edu.ucsb.cs156.courses.config.JpaAuditingConfig</param>
                     </excludedClasses>
                     <excludedTestClasses>
-                        <param>edu.ucsb.cs156.example.integration.*</param>
+                        <param>edu.ucsb.cs156.courses.integration.*</param>
                     </excludedTestClasses>
                     <outputFormats>
                         <outputFormat>HTML</outputFormat>

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
-import edu.ucsb.cs156.courses.jobs.TestJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.UploadGradeDataJob;
 import edu.ucsb.cs156.courses.jobs.UploadGradeDataJobFactory;
@@ -86,17 +85,6 @@ public class JobsController extends ApiController {
     }
     jobsRepository.deleteById(id);
     return Map.of("message", String.format("Job with id %d deleted", id));
-  }
-
-  @Operation(summary = "Launch Test Job (click fail if you want to test exception handling)")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @PostMapping("/launch/testjob")
-  public Job launchTestJob(
-      @Parameter(name = "fail") @RequestParam Boolean fail,
-      @Parameter(name = "sleepMs") @RequestParam Integer sleepMs) {
-
-    TestJob testJob = TestJob.builder().fail(fail).sleepMs(sleepMs).build();
-    return jobService.runAsJob(testJob);
   }
 
   @Operation(summary = "Launch Job to Update Course Data")

--- a/src/main/java/edu/ucsb/cs156/courses/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/CurrentUserServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service("currentUser")
+@Primary
 public class CurrentUserServiceImpl extends CurrentUserService {
   @Autowired private UserRepository userRepository;
 

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContextFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContextFactory.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobContextFactory {
+  private final JobsRepository repository;
+
+  public JobContextFactory(JobsRepository repository) {
+    this.repository = repository;
+  }
+
+  public JobContext createContext(Job job) {
+    return new JobContext(repository, job);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
@@ -14,6 +14,8 @@ public class JobService {
 
   @Autowired private CurrentUserService currentUserService;
 
+  @Autowired private JobContextFactory contextFactory;
+
   @Lazy @Autowired private JobService self;
 
   public Job runAsJob(JobContextConsumer jobFunction) {
@@ -27,7 +29,7 @@ public class JobService {
 
   @Async
   public void runJobAsync(Job job, JobContextConsumer jobFunction) {
-    JobContext context = new JobContext(jobsRepository, job);
+    JobContext context = contextFactory.createContext(job);
 
     try {
       jobFunction.accept(context);

--- a/src/test/java/edu/ucsb/cs156/courses/integration/AsyncJobTestsIT.java
+++ b/src/test/java/edu/ucsb/cs156/courses/integration/AsyncJobTestsIT.java
@@ -1,0 +1,38 @@
+package edu.ucsb.cs156.courses.integration;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobContextFactory;
+import edu.ucsb.cs156.courses.services.jobs.JobService;
+import edu.ucsb.cs156.courses.testconfig.TestConfig;
+import edu.ucsb.cs156.courses.testconfig.TestJob;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@Import(TestConfig.class)
+public class AsyncJobTestsIT {
+
+  @Autowired private JobService jobService;
+
+  @Autowired private JobContextFactory contextFactory;
+
+  @MockitoBean private JobsRepository jobsRepository;
+
+  @Test
+  void async_job_actually_runs_asynchronously() {
+    TestJob testJob = TestJob.builder().fail(false).sleepMs(2000).build();
+    Job job = jobService.runAsJob(testJob);
+    assertEquals("running", job.getStatus(), "Job should be running");
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertEquals("complete", job.getStatus(), "Job should be complete"));
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/TestJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/TestJobTests.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.testconfig.TestJob;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.security.test.context.support.WithMockUser;

--- a/src/test/java/edu/ucsb/cs156/courses/services/JobServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/JobServiceTests.java
@@ -1,0 +1,148 @@
+package edu.ucsb.cs156.courses.services;
+
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.models.CurrentUser;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextFactory;
+import edu.ucsb.cs156.courses.services.jobs.JobService;
+import edu.ucsb.cs156.courses.testconfig.TestJob;
+import java.util.List;
+import java.util.Optional;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class JobServiceTests {
+
+  @Mock private JobsRepository jobRepository;
+
+  @Mock private JobService injectedJobService;
+
+  @Mock private JobContextFactory contextFactory;
+
+  @Mock private CurrentUserService currentUserService;
+
+  @InjectMocks private JobService jobService;
+
+  private CurrentUser user;
+
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+
+    user =
+        CurrentUser.builder()
+            .roles(List.of(new SimpleGrantedAuthority("ROLE_ADMIN")))
+            .user(User.builder().id(1L).build())
+            .build();
+  }
+
+  @Test
+  void test_getJobLogs_with_log() {
+    // Arrange
+    Long jobId = 1L;
+    Job job = Job.builder().build();
+    job.setLog("This is a job log");
+    when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+
+    // Act
+    String result = jobService.getLongJob(jobId);
+
+    // Assert
+    assertEquals("This is a job log", result);
+  }
+
+  @Test
+  void test_getJobLogs_with_null_log() {
+    // Arrange
+    Long jobId = 2L;
+    Job job = Job.builder().build();
+    job.setLog(null);
+    when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+
+    // Act
+    String result = jobService.getLongJob(jobId);
+
+    // Assert
+    assertEquals("", result);
+  }
+
+  @Test
+  void test_getJobLogs_job_not_found() {
+    // Arrange
+    Long jobId = 3L;
+    when(jobRepository.findById(jobId)).thenReturn(Optional.empty());
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException.class, () -> jobService.getLongJob(jobId));
+  }
+
+  @Test
+  void runAsJob_fires_correctly() {
+    TestJob job = TestJob.builder().fail(false).sleepMs(0).build();
+
+    Job fireJob = Job.builder().createdBy(user.getUser()).status("running").build();
+
+    doNothing().when(injectedJobService).runJobAsync(any(), any());
+    when(currentUserService.getUser()).thenReturn(user.getUser());
+
+    MatcherAssert.assertThat(fireJob, samePropertyValuesAs(jobService.runAsJob(job)));
+    verify(jobRepository).save(eq(fireJob));
+    verify(injectedJobService).runJobAsync(eq(fireJob), eq(job));
+  }
+
+  @Test
+  void runAsyncJob_fires_correctly() throws Exception {
+    TestJob job = mock(TestJob.class);
+    JobContext context = mock(JobContext.class);
+
+    Job passedJob = Job.builder().status("running").build();
+    Job expectedReturn = Job.builder().status("complete").build();
+
+    doNothing().when(job).accept(any());
+
+    when(contextFactory.createContext(eq(passedJob))).thenReturn(context);
+    doNothing().when(job).accept(eq(context));
+
+    jobService.runJobAsync(passedJob, job);
+    verify(jobRepository).save(eq(expectedReturn));
+    verify(job).accept(eq(context));
+    verify(contextFactory).createContext(eq(passedJob));
+  }
+
+  @Test
+  void runAsyncJob_handles_error() throws Exception {
+    TestJob job = mock(TestJob.class);
+    JobContext context = mock(JobContext.class);
+
+    Job passedJob = Job.builder().status("running").build();
+    doNothing().when(job).accept(any());
+
+    when(contextFactory.createContext(eq(passedJob))).thenReturn(context);
+    doThrow(new Exception("fail!")).when(job).accept(eq(context));
+
+    jobService.runJobAsync(passedJob, job);
+    verify(context).log(contains("fail!"));
+    verify(job).accept(eq(context));
+    verify(contextFactory).createContext(eq(passedJob));
+    assertEquals("error", passedJob.getStatus());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobContextFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobContextFactoryTests.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.courses.services.Jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockitoAnnotations;
+
+public class JobContextFactoryTests {
+
+  @Mock private JobsRepository jobsRepository;
+
+  @InjectMocks private JobContextFactory contextFactory;
+
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void factory_returns_jobContext() {
+    Job job = mock(Job.class);
+    try (MockedConstruction<JobContext> mockedConstruction =
+        mockConstruction(
+            JobContext.class,
+            (mock, context) -> {
+              assertEquals(jobsRepository, context.arguments().getFirst());
+              assertEquals(job, context.arguments().get(1));
+            })) {
+      JobContext createdContext = contextFactory.createContext(job);
+      JobContext constructedMock = mockedConstruction.constructed().getFirst();
+      assertEquals(createdContext, constructedMock);
+    }
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobContextTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/Jobs/JobContextTests.java
@@ -1,0 +1,51 @@
+package edu.ucsb.cs156.courses.services.Jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class JobContextTests {
+  @Test
+  public void when_jobs_repository_is_null_does_not_save() throws Exception {
+
+    // arrange
+
+    Job job1 = Job.builder().build();
+    JobContext ctx = new JobContext(null, job1);
+
+    // act
+    ctx.log("This is a log message");
+
+    // assert
+    assertEquals("This is a log message", job1.getLog());
+  }
+
+  @Test
+  public void jobsContext_can_save_log_messages() throws Exception {
+    JobsRepository repository = mock(JobsRepository.class);
+    Job job = Job.builder().build();
+    Job jobAfterFirstSave = Job.builder().log("This is a log message").build();
+    Job jobAfterSecondSave = Job.builder().log("This is a log message\nSecond log message").build();
+
+    JobContext ctx = new JobContext(repository, job);
+
+    InOrder inOrder = Mockito.inOrder(repository);
+
+    ctx.log("This is a log message");
+    assertEquals("This is a log message", job.getLog());
+
+    inOrder.verify(repository).save(jobAfterFirstSave);
+
+    ctx.log("Second log message");
+    assertEquals("This is a log message\nSecond log message", job.getLog());
+
+    inOrder.verify(repository).save(jobAfterSecondSave);
+    inOrder.verifyNoMoreInteractions();
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/courses/testconfig/MockCurrentUserServiceImpl.java
@@ -10,7 +10,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.stereotype.Service;
 
 @Slf4j
-@Service("currentUser")
+@Service("mockCurrentUser")
 public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
 
   public User getMockUser(SecurityContext securityContext, Authentication authentication) {

--- a/src/test/java/edu/ucsb/cs156/courses/testconfig/TestJob.java
+++ b/src/test/java/edu/ucsb/cs156/courses/testconfig/TestJob.java
@@ -1,4 +1,4 @@
-package edu.ucsb.cs156.courses.jobs;
+package edu.ucsb.cs156.courses.testconfig;
 
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;


### PR DESCRIPTION
In this PR, I rework the jobs system to work similarly to proj-spring-spoolers' PR 2: https://github.com/ucsb-cs156/proj-spring-spooler/pull/2

This allows us to move TestJob to the testing section of the project, avoiding having to await() for its' results, hopefully speeding up pitest.

Additionally, I add an integration test ensuring async functionality works.

Deployed to https://courses-qa.dokku-00.cs.ucsb.edu/