### PR TITLE
pc - add new endpoint for CSV downloads with more options (and refactor tests)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -33,4 +33,24 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
 
   @Query("{'courseInfo.quarter': { $eq: ?0 } }")
   List<ConvertedSection> findByQuarter(String quarter);
+
+  @Query(
+      "{'courseInfo.quarter': { $eq: ?0 }, 'courseInfo.courseId': { $regex: ?1 }, 'section.section': { $regex: '00$' } }")
+  List<ConvertedSection> findLecturesByQuarterAndSubjectArea(String quarter, String subjectArea);
+
+  /**
+   * Find sections by quarter and subject area.
+   *
+   * @param quarter Quarter in yyyyq format
+   * @param subjectArea regex (first eight should be subjectArea, then next character determines
+   *     level; e.g. ' ' for lower div ugrad, 1 for upper div ugrad, 2 or above for grad)
+   * @param sectionRegex use `00$` to omit sections or `.*` for all sections
+   * @param minTimeLocations use 0 for all courses (including independent studies), 1 for only
+   *     course that have a time and/or locations assigned
+   * @return
+   */
+  @Query(
+      "{'courseInfo.quarter': { $eq: ?0 }, 'courseInfo.courseId': { $regex: ?1 }, 'section.section': { $regex: ?2 }, $expr: { $gte: [ { $size: '$section.timeLocations' }, ?3 ] } }")
+  List<ConvertedSection> findByQuarterAndSubjectArea(
+      String quarter, String subjectArea, String sectionRegex, int minTimeLocations);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -34,9 +34,6 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
   @Query("{'courseInfo.quarter': { $eq: ?0 } }")
   List<ConvertedSection> findByQuarter(String quarter);
 
-  @Query(
-      "{'courseInfo.quarter': { $eq: ?0 }, 'courseInfo.courseId': { $regex: ?1 }, 'section.section': { $regex: '00$' } }")
-  List<ConvertedSection> findLecturesByQuarterAndSubjectArea(String quarter, String subjectArea);
 
   /**
    * Find sections by quarter and subject area.

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -34,7 +34,6 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
   @Query("{'courseInfo.quarter': { $eq: ?0 } }")
   List<ConvertedSection> findByQuarter(String quarter);
 
-
   /**
    * Find sections by quarter and subject area.
    *

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CoursesCSVController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CoursesCSVController.java
@@ -137,7 +137,6 @@ public class CoursesCSVController extends ApiController {
           boolean withTimeLocations)
       throws Exception, IOException {
 
-    // String formattedSubjectArea = String.format("'%8s'", subjectArea);
     StreamingResponseBody stream =
         (outputStream) -> {
           String sectionRegex = omitSections ? "00$" : ".*";

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CoursesCSVController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CoursesCSVController.java
@@ -42,7 +42,7 @@ public class CoursesCSVController extends ApiController {
   @Autowired private SectionCSVLineService sectionCsvLineService;
 
   @Operation(
-      summary = "Download Course List as CSV File",
+      summary = "Download Complete Course List for a quarter as a CSV File",
       description = "Returns a CSV file as a response",
       responses = {
         @ApiResponse(
@@ -63,6 +63,97 @@ public class CoursesCSVController extends ApiController {
     StreamingResponseBody stream =
         (outputStream) -> {
           Iterable<ConvertedSection> iterable = convertedSectionCollection.findByQuarter(yyyyq);
+
+          List<SectionCSVLine> list =
+              Streamable.of(iterable).toList().stream()
+                  .map(
+                      section -> {
+                        return SectionCSVLine.toSectionCSVLine(section);
+                      })
+                  .collect(Collectors.toList());
+
+          try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+            try {
+              StatefulBeanToCsv<SectionCSVLine> beanToCsvWriter =
+                  sectionCsvLineService.getStatefulBeanToCSV(writer);
+              beanToCsvWriter.write(list);
+            } catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
+              log.error("Error writing CSV file", e);
+              throw new IOException("Error writing CSV file: " + e.getMessage());
+            }
+          }
+        };
+
+    return ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            String.format("attachment;filename=courses_%s.csv", yyyyq))
+        .header(HttpHeaders.CONTENT_TYPE, "text/csv; charset=UTF-8")
+        .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION)
+        .body(stream);
+  }
+
+  @Operation(
+      summary = "Download Course List for a subject area and quarter as a CSV File",
+      description = "Returns a CSV file as a response",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "CSV file",
+            content =
+                @Content(
+                    mediaType = "text/csv",
+                    schema = @Schema(type = "string", format = "binary"))),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+      })
+  @GetMapping(value = "/byQuarterAndSubjectArea", produces = "text/csv")
+  public ResponseEntity<StreamingResponseBody> csvForCoursesQuarterAndSubjectArea(
+      @Parameter(name = "yyyyq", description = "quarter in yyyyq format", example = "20261")
+          @RequestParam
+          String yyyyq,
+      @Parameter(name = "subjectArea", description = "subject area", example = "CMPSC")
+          @RequestParam
+          String subjectArea,
+      @Parameter(
+              name = "level",
+              description = "U for undergrad, G for graduate, A for all (default: U)",
+              example = "",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"A", "U", "G"}))
+          @RequestParam(defaultValue = "U")
+          String level,
+      @Parameter(name = "omitSections", description = "omit sections", example = "true")
+          @RequestParam(defaultValue = "true")
+          boolean omitSections,
+      @Parameter(
+              name = "withTimeLocations",
+              description =
+                  "return only courses that have times and/or locations assigned (e.g. no independent study type courses)",
+              example = "true")
+          @RequestParam(defaultValue = "true")
+          boolean withTimeLocations)
+      throws Exception, IOException {
+
+    // String formattedSubjectArea = String.format("'%8s'", subjectArea);
+    StreamingResponseBody stream =
+        (outputStream) -> {
+          String sectionRegex = omitSections ? "00$" : ".*";
+          String courseLevelRegex =
+              level.equals("A") ? "" : level.equals("G") ? "[23456789]" : "[ 1]";
+          String courseIdRegex = String.format("^%-8s", subjectArea) + courseLevelRegex;
+          Iterable<ConvertedSection> iterable =
+              convertedSectionCollection.findByQuarterAndSubjectArea(
+                  yyyyq, courseIdRegex, sectionRegex, withTimeLocations ? 1 : 0);
+
+          log.info(
+              "Found {} sections for quarter {} and courseIdRegex <{}> and sectionRegex <{}>",
+              Streamable.of(iterable).toList().size(),
+              yyyyq,
+              courseIdRegex,
+              sectionRegex);
 
           List<SectionCSVLine> list =
               Streamable.of(iterable).toList().stream()

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.courses.documents;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.ucsb.cs156.courses.entities.EnrollmentDataPoint;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -54,5 +55,35 @@ public class ConvertedSection {
     public int compare(ConvertedSection o1, ConvertedSection o2) {
       return o2.getCourseInfo().getQuarter().compareTo(o1.getCourseInfo().getQuarter());
     }
+  }
+
+  @JsonIgnore
+  public String getDays() {
+    if (this.getSection().getTimeLocations() == null) {
+      return "";
+    }
+    return this.getSection().getTimeLocations().stream()
+        .map(timeLocation -> timeLocation.getDays())
+        .collect(Collectors.joining(", "));
+  }
+
+  @JsonIgnore
+  public String getBeginTimes() {
+    if (this.getSection().getTimeLocations() == null) {
+      return "";
+    }
+    return this.getSection().getTimeLocations().stream()
+        .map(timeLocation -> timeLocation.getBeginTime())
+        .collect(Collectors.joining(", "));
+  }
+
+  @JsonIgnore
+  public String getLocations() {
+    if (this.getSection().getTimeLocations() == null) {
+      return "";
+    }
+    return this.getSection().getTimeLocations().stream()
+        .map(timeLocation -> timeLocation.getBuilding() + " " + timeLocation.getRoom())
+        .collect(Collectors.joining(", "));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/models/SectionCSVLine.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SectionCSVLine.java
@@ -20,12 +20,16 @@ public class SectionCSVLine {
   private String maxEnroll;
   private String status;
   private String ges;
+  private String days;
+  private String beginTime;
+  private String location;
 
   public static String intToStringWithDefault(Integer i) {
     return i == null ? "0" : i.toString();
   }
 
   public static SectionCSVLine toSectionCSVLine(ConvertedSection cs) {
+
     return SectionCSVLine.builder()
         .quarter(cs.getCourseInfo().getQuarter())
         .courseId(cs.getCourseInfo().getCourseId())
@@ -35,6 +39,9 @@ public class SectionCSVLine {
         .instructor(cs.getSection().instructorList())
         .status(cs.getSection().status())
         .ges(cs.getCourseInfo().ges())
+        .days(cs.getDays())
+        .beginTime(cs.getBeginTimes())
+        .location(cs.getLocations())
         .build();
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
@@ -20,7 +20,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,7 +32,7 @@ public class CourseOverTimeControllerTests {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockBean ConvertedSectionCollection convertedSectionCollection;
+  @MockitoBean ConvertedSectionCollection convertedSectionCollection;
   @MockitoBean UserRepository userRepository;
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CoursesCSVControllerTests.java
@@ -1,8 +1,12 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -26,28 +30,47 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(controllers = {CoursesCSVController.class})
 @Import(TestConfig.class)
 public class CoursesCSVControllerTests extends ControllerTestCase {
+  @org.springframework.beans.factory.annotation.Autowired
+  private ConvertedSectionCollection convertedSectionCollection;
 
-  @MockBean private ConvertedSectionCollection convertedSectionCollection;
+  @org.springframework.beans.factory.annotation.Autowired
+  private SectionCSVLineService sectionCsvLineService;
 
-  @MockBean(answer = Answers.CALLS_REAL_METHODS)
-  SectionCSVLineService sectionCsvLineService;
+  @org.springframework.beans.factory.annotation.Autowired private UserRepository userRepository;
 
   @Mock(answer = Answers.CALLS_REAL_METHODS)
   StatefulBeanToCsv<SectionCSVLine> csvWriter;
 
-  @MockitoBean UserRepository userRepository;
+  @org.springframework.boot.test.context.TestConfiguration
+  static class TestBeansConfig {
+
+    @org.springframework.context.annotation.Bean
+    public ConvertedSectionCollection convertedSectionCollection() {
+      return org.mockito.Mockito.mock(ConvertedSectionCollection.class);
+    }
+
+    @org.springframework.context.annotation.Bean
+    public SectionCSVLineService sectionCsvLineService() {
+      return org.mockito.Mockito.mock(
+          SectionCSVLineService.class,
+          org.mockito.Mockito.withSettings().defaultAnswer(org.mockito.Answers.CALLS_REAL_METHODS));
+    }
+
+    @org.springframework.context.annotation.Bean
+    public UserRepository userRepository() {
+      return org.mockito.Mockito.mock(UserRepository.class);
+    }
+  }
 
   @Test
-  public void test_csv_exception() throws Exception {
+  public void testCsvForQuarter_exception() throws Exception {
 
     // arrange
 
@@ -149,12 +172,12 @@ public class CoursesCSVControllerTests extends ControllerTestCase {
 
     String expectedCSVOutput =
         """
-                "COURSEID","ENROLLED","GES","INSTRUCTOR","MAXENROLL","QUARTER","SECTION","STATUS"
-                "CMPSC    8 -1","55","C (L&S), QNT (L&S)","MIRZA D","150","20252","0100",""
-                "CMPSC    8 -1","30","C (L&S), QNT (L&S)","MIRZA D","30","20252","0101",""
-                "CMPSC    8 -1","25","C (L&S), QNT (L&S)","MIRZA D","30","20252","0102","Closed"
-                "CMPSC    8 -1","0","C (L&S), QNT (L&S)","MIRZA D","30","20252","0103","Closed"
-                "CMPSC    8 -1","0","C (L&S), QNT (L&S)","MIRZA D","30","20252","0104",""
+                "BEGINTIME","COURSEID","DAYS","ENROLLED","GES","INSTRUCTOR","LOCATION","MAXENROLL","QUARTER","SECTION","STATUS"
+                "","CMPSC    8 -1","","55","C (L&S), QNT (L&S)","MIRZA D","","150","20252","0100",""
+                "","CMPSC    8 -1","","30","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0101",""
+                "","CMPSC    8 -1","","25","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0102","Closed"
+                "","CMPSC    8 -1","","0","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0103","Closed"
+                "","CMPSC    8 -1","","0","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0104",""
                 """;
 
     doReturn(dataPoints).when(convertedSectionCollection).findByQuarter(yyyyq);
@@ -168,6 +191,217 @@ public class CoursesCSVControllerTests extends ControllerTestCase {
             .andReturn();
 
     verify(convertedSectionCollection, times(1)).findByQuarter(yyyyq);
+    verify(sectionCsvLineService, times(1)).getStatefulBeanToCSV(any());
+
+    assertEquals(expectedCSVOutput, response.getResponse().getContentAsString());
+  }
+
+  @Test
+  public void testCsvForQuarterAndSubjectArea_exception() throws Exception {
+
+    // arrange
+
+    String yyyyq = "20252";
+
+    doReturn(List.of()).when(convertedSectionCollection).findByQuarter(yyyyq);
+    doReturn(csvWriter).when(sectionCsvLineService).getStatefulBeanToCSV(any());
+
+    doThrow(new CsvDataTypeMismatchException()).when(csvWriter).write(anyList());
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/courses/csv/byQuarterAndSubjectArea?yyyyq=20252&subjectArea=CMPSC"))
+            .andExpect(request().asyncStarted())
+            .andDo(MvcResult::getAsyncResult)
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String actualResponse = response.getResponse().getContentAsString();
+    String expectedMessage = "";
+    assertEquals(expectedMessage, actualResponse);
+  }
+
+  @Test
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  public void testCsvForQuarterAndSubjectArea_success_defaults() throws Exception {
+    String yyyyq = "20252";
+
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter(yyyyq)
+            .courseId("CMPSC    8 -1")
+            .title("INTRO TO COMP SCI")
+            .generalEducation(
+                List.of(
+                    GeneralEducation.builder().geCode("C").geCollege("L&S").build(),
+                    GeneralEducation.builder().geCode("QNT").geCollege("L&S").build()))
+            .build();
+
+    Section section0100 =
+        Section.builder()
+            .section("0100")
+            .enrolledTotal(55)
+            .maxEnroll(150)
+            .courseCancelled("")
+            .classClosed("")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0101 =
+        Section.builder()
+            .section("0101")
+            .enrolledTotal(30)
+            .maxEnroll(30)
+            .courseCancelled("")
+            .classClosed("")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0102 =
+        Section.builder()
+            .section("0102")
+            .enrolledTotal(25)
+            .maxEnroll(30)
+            .courseCancelled("")
+            .classClosed("Y")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0103 =
+        Section.builder()
+            .section("0103")
+            .enrolledTotal(0)
+            .maxEnroll(30)
+            .courseCancelled("")
+            .classClosed("Y")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Section section0104 =
+        Section.builder()
+            .section("0104")
+            .enrolledTotal(0)
+            .maxEnroll(30)
+            .courseCancelled("T")
+            .classClosed("")
+            .instructors(List.of(Instructor.builder().instructor("MIRZA D").build()))
+            .build();
+
+    Stream<Section> sections =
+        Stream.of(section0100, section0101, section0102, section0103, section0104);
+    List<ConvertedSection> dataPoints =
+        sections
+            .map(section -> ConvertedSection.builder().courseInfo(info).section(section).build())
+            .toList();
+
+    String expectedCSVOutput =
+        """
+                "BEGINTIME","COURSEID","DAYS","ENROLLED","GES","INSTRUCTOR","LOCATION","MAXENROLL","QUARTER","SECTION","STATUS"
+                "","CMPSC    8 -1","","55","C (L&S), QNT (L&S)","MIRZA D","","150","20252","0100",""
+                "","CMPSC    8 -1","","30","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0101",""
+                "","CMPSC    8 -1","","25","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0102","Closed"
+                "","CMPSC    8 -1","","0","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0103","Closed"
+                "","CMPSC    8 -1","","0","C (L&S), QNT (L&S)","MIRZA D","","30","20252","0104",""
+                """;
+
+    doReturn(dataPoints)
+        .when(convertedSectionCollection)
+        .findByQuarterAndSubjectArea(yyyyq, "^CMPSC   [ 1]", "00$", 1);
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/courses/csv/byQuarterAndSubjectArea?yyyyq=20252&subjectArea=CMPSC"))
+            .andExpect(request().asyncStarted())
+            .andDo(MvcResult::getAsyncResult)
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(convertedSectionCollection, times(1))
+        .findByQuarterAndSubjectArea(yyyyq, "^CMPSC   [ 1]", "00$", 1);
+    verify(sectionCsvLineService, times(1)).getStatefulBeanToCSV(any());
+
+    assertEquals(expectedCSVOutput, response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  public void testCsvForQuarterAndSubjectArea_success_G_false_false() throws Exception {
+    String yyyyq = "20252";
+
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter(yyyyq)
+            .courseId("CMPSC   292A -1")
+            .title("SPEC TOP FOUN ALGO")
+            .build();
+
+    Section section0100 =
+        Section.builder()
+            .section("0100")
+            .enrolledTotal(13)
+            .maxEnroll(35)
+            .courseCancelled("")
+            .classClosed("")
+            .instructors(List.of(Instructor.builder().instructor("LOKSHTANOV D").build()))
+            .build();
+    Stream<Section> sections = Stream.of(section0100);
+    List<ConvertedSection> dataPoints =
+        sections
+            .map(section -> ConvertedSection.builder().courseInfo(info).section(section).build())
+            .toList();
+    String expectedCSVOutput =
+        """
+                "BEGINTIME","COURSEID","DAYS","ENROLLED","GES","INSTRUCTOR","LOCATION","MAXENROLL","QUARTER","SECTION","STATUS"
+                "","CMPSC   292A -1","","13","","LOKSHTANOV D","","35","20252","0100",""
+                """;
+
+    doReturn(dataPoints)
+        .when(convertedSectionCollection)
+        .findByQuarterAndSubjectArea(yyyyq, "^CMPSC   [23456789]", ".*", 0);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                get(
+                    "/api/courses/csv/byQuarterAndSubjectArea?yyyyq=20252&subjectArea=CMPSC&level=G&omitSections=false&withTimeLocations=false"))
+            .andExpect(request().asyncStarted())
+            .andDo(MvcResult::getAsyncResult)
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(convertedSectionCollection, times(1))
+        .findByQuarterAndSubjectArea(yyyyq, "^CMPSC   [23456789]", ".*", 0);
+    verify(sectionCsvLineService, times(1)).getStatefulBeanToCSV(any());
+
+    assertEquals(expectedCSVOutput, response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  public void testCsvForQuarterAndSubjectArea_success_level_A_false_false() throws Exception {
+    String yyyyq = "20252";
+    List<ConvertedSection> dataPoints = List.of();
+    String expectedCSVOutput = "";
+
+    doReturn(dataPoints)
+        .when(convertedSectionCollection)
+        .findByQuarterAndSubjectArea(yyyyq, "^CMPSC   ", ".*", 0);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                get(
+                    "/api/courses/csv/byQuarterAndSubjectArea?yyyyq=20252&subjectArea=CMPSC&level=A&omitSections=false&withTimeLocations=false"))
+            .andExpect(request().asyncStarted())
+            .andDo(MvcResult::getAsyncResult)
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(convertedSectionCollection, times(1))
+        .findByQuarterAndSubjectArea(yyyyq, "^CMPSC   ", ".*", 0);
     verify(sectionCsvLineService, times(1)).getStatefulBeanToCSV(any());
 
     assertEquals(expectedCSVOutput, response.getResponse().getContentAsString());

--- a/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
@@ -74,4 +74,43 @@ public class ConvertedSectionTests {
     result = comparator.compare(cs1, cs2);
     assertTrue(result < 0); // cs1 is later than cs2 (sorting descending)
   }
+
+  @Test
+  public void test_getDays() throws JsonProcessingException {
+    List<ConvertedSection> cs =
+        mapper.readValue(
+            CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH3B,
+            new TypeReference<List<ConvertedSection>>() {});
+    ConvertedSection cs1 = cs.get(0);
+    ConvertedSection cs2 = cs.get(1);
+
+    assertEquals("M W F  ", cs1.getDays());
+    assertEquals(" T     ", cs2.getDays());
+  }
+
+  @Test
+  public void test_getLocations() throws JsonProcessingException {
+    List<ConvertedSection> cs =
+        mapper.readValue(
+            CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH3B,
+            new TypeReference<List<ConvertedSection>>() {});
+    ConvertedSection cs1 = cs.get(0);
+    ConvertedSection cs2 = cs.get(1);
+
+    assertEquals("LSB 1001", cs1.getLocations());
+    assertEquals("HSSB 1231", cs2.getLocations());
+  }
+
+  @Test
+  public void test_getBeginTimes() throws JsonProcessingException {
+    List<ConvertedSection> cs =
+        mapper.readValue(
+            CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH3B,
+            new TypeReference<List<ConvertedSection>>() {});
+    ConvertedSection cs1 = cs.get(0);
+    ConvertedSection cs2 = cs.get(1);
+
+    assertEquals("11:00", cs1.getBeginTimes());
+    assertEquals("17:00", cs2.getBeginTimes());
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/models/SectionCSVLineTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/models/SectionCSVLineTests.java
@@ -25,6 +25,9 @@ public class SectionCSVLineTests {
     line.setMaxEnroll("80");
     line.setStatus("Open");
     line.setGes("None");
+    line.setDays(" T R   ");
+    line.setBeginTime("17:00");
+    line.setLocation("ILP 2211");
 
     // Use getters to confirm
     assertEquals("20251", line.getQuarter());
@@ -33,7 +36,18 @@ public class SectionCSVLineTests {
 
     // Force coverage for equals/hashCode + all-args constructor
     SectionCSVLine same =
-        new SectionCSVLine("20251", "CMPSC 156", "0101", "Conrad", "50", "80", "Open", "None");
+        new SectionCSVLine(
+            "20251",
+            "CMPSC 156",
+            "0101",
+            "Conrad",
+            "50",
+            "80",
+            "Open",
+            "None",
+            " T R   ",
+            "17:00",
+            "ILP 2211");
 
     assertEquals(line, same);
     assertEquals(line.hashCode(), same.hashCode());


### PR DESCRIPTION
Deployed at https://courses-qa.dokku-00.cs.ucsb.edu

In this PR, we add a new backend endpoint for CSV downloads that allows the caller more control over what courses are downloaded.

We also add three new columns: startTime, location, and days to the download.

Here is a screenshot of the new swagger endpoint:

<img width="1312" height="702" alt="image" src="https://github.com/user-attachments/assets/5ffea78d-d927-42d3-9b09-392915359e38" />
