### PR TITLE
pc - add downloads page placeholder

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,8 @@ import CourseOverTimeBuildingsIndexPage from "main/pages/CourseOverTime/CourseOv
 import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/GeneralEducationSearchPage";
 import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexPage";
 
+import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
+
 function App() {
   const { data: currentUser } = useCurrentUser();
 
@@ -116,6 +118,7 @@ function App() {
           path="/generaleducation/search"
           element={<GeneralEducationSearchPage />}
         />
+        <Route exact path="/downloads" element={<CSVDownloadsPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -155,6 +155,9 @@ export default function AppNavbar({
             </Nav>
 
             <Nav className="ml-auto">
+              <Nav.Link href="/downloads" data-testid="appnavbar-downloads">
+                Downloads
+              </Nav.Link>
               {currentUser && currentUser.loggedIn ? (
                 <>
                   <Navbar.Text className="me-3" as={Link} to="/profile">

--- a/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
+++ b/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function GeneralEducationSearchPage() {
+  return (
+    <BasicLayout>
+      <div className="container mt-3">
+        <h1>CSV Downloads</h1>
+
+        <h2>Download by Quarter and Subject Area</h2>
+
+        <p>
+          Improved UX coming soon; for now, visit{" "}
+          <a href="/swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCoursesQuarterAndSubjectArea">
+            this link
+          </a>
+          , using <code>qyyyy</code> format for quarter (e.g. <code>20254</code>{" "}
+          for F25, <code>20261</code> for W26, <code>20262</code> for S26, etc)
+        </p>
+
+        <h2>Download all UCSB classes by Quarter</h2>
+
+        <p>
+          Improved UX coming soon; for now, visit{" "}
+          <a href="//swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCourses">
+            this link
+          </a>{" "}
+          using <code>qyyyy</code> format for quarter (e.g. <code>20254</code>{" "}
+          for F25, <code>20261</code> for W26, <code>20262</code> for S26, etc)
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -25,6 +25,15 @@ describe("AppNavbar tests", () => {
     expect(
       await screen.findByText("Welcome, pconrad.cis@gmail.com"),
     ).toBeInTheDocument();
+
+    expect(screen.getByTestId("appnavbar-downloads")).toBeInTheDocument();
+    expect(screen.getByTestId("appnavbar-downloads")).toHaveAttribute(
+      "href",
+      "/downloads",
+    );
+    expect(screen.getByTestId("appnavbar-downloads")).toHaveTextContent(
+      "Downloads",
+    );
   });
 
   test("renders correctly for admin user", async () => {

--- a/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
+++ b/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
+
+describe("CSVDownloadsPage tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CSVDownloadsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("CSV Downloads")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Deployed to https://courses-qa.dokku-00.cs.ucsb.edu

In this PR, we add a placeholder for a downloads page.

Temporarily, it includes links directly to the swagger endpoints for the downloads.

Eventually, we hope that it will have an accordion style page similar to the jobs page, but with cards that have React forms to fill in to get downloads along with nice tooltips to explain each of the options.

# Screenshots

<img width="1234" height="396" alt="image" src="https://github.com/user-attachments/assets/6b2fbf1d-62ae-4985-a0e5-b9a9f0a85472" />


