### PR TITLE
UI for CSV Downloads

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,8 @@ import CourseOverTimeBuildingsIndexPage from "main/pages/CourseOverTime/CourseOv
 import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/GeneralEducationSearchPage";
 import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexPage";
 
+import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
+
 function App() {
   const { data: currentUser } = useCurrentUser();
 
@@ -116,6 +118,7 @@ function App() {
           path="/generaleducation/search"
           element={<GeneralEducationSearchPage />}
         />
+        <Route exact path="/downloads" element={<CSVDownloadsPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,6 @@ import CourseOverTimeBuildingsIndexPage from "main/pages/CourseOverTime/CourseOv
 
 import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/GeneralEducationSearchPage";
 import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexPage";
-
 import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
 
 function App() {

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -155,6 +155,9 @@ export default function AppNavbar({
             </Nav>
 
             <Nav className="ml-auto">
+              <Nav.Link href="/downloads" data-testid="appnavbar-downloads">
+                Downloads
+              </Nav.Link>
               {currentUser && currentUser.loggedIn ? (
                 <>
                   <Navbar.Text className="me-3" as={Link} to="/profile">

--- a/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
+++ b/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function GeneralEducationSearchPage() {
+  return (
+    <BasicLayout>
+      <div className="container mt-3">
+        <h1>CSV Downloads</h1>
+
+        <h2>Download by Quarter and Subject Area</h2>
+
+        <p>
+          Improved UX coming soon; for now, visit{" "}
+          <a href="/swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCoursesQuarterAndSubjectArea">
+            this link
+          </a>
+          , using <code>qyyyy</code> format for quarter (e.g. <code>20254</code>{" "}
+          for F25, <code>20261</code> for W26, <code>20262</code> for S26, etc)
+        </p>
+
+        <h2>Download all UCSB classes by Quarter</h2>
+
+        <p>
+          Improved UX coming soon; for now, visit{" "}
+          <a href="//swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCourses">
+            this link
+          </a>{" "}
+          using <code>qyyyy</code> format for quarter (e.g. <code>20254</code>{" "}
+          for F25, <code>20261</code> for W26, <code>20262</code> for S26, etc)
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
+++ b/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
@@ -1,33 +1,44 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Accordion } from "react-bootstrap";
 
-export default function GeneralEducationSearchPage() {
+export default function CSVDownloadsPage() {
   return (
     <BasicLayout>
       <div className="container mt-3">
         <h1>CSV Downloads</h1>
+        <Accordion>
+          <Accordion.Item eventKey="by-quarter" key="by-quarter">
+            <Accordion.Header>Download all UCSB classes by Quarter</Accordion.Header>
+            <Accordion.Body>
+              Download all classes for a given quarter (in <code>yyyyq</code>{" "}
+              format). For now, use{" "}
+              <a href="/swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCourses">
+                this endpoint
+              </a>
+              . Example quarters: <code>20254</code> (F25), <code>20261</code>{" "}
+              (W26), <code>20262</code> (S26).
+            </Accordion.Body>
+          </Accordion.Item>
 
-        <h2>Download by Quarter and Subject Area</h2>
-
-        <p>
-          Improved UX coming soon; for now, visit{" "}
-          <a href="/swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCoursesQuarterAndSubjectArea">
-            this link
-          </a>
-          , using <code>qyyyy</code> format for quarter (e.g. <code>20254</code>{" "}
-          for F25, <code>20261</code> for W26, <code>20262</code> for S26, etc)
-        </p>
-
-        <h2>Download all UCSB classes by Quarter</h2>
-
-        <p>
-          Improved UX coming soon; for now, visit{" "}
-          <a href="//swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCourses">
-            this link
-          </a>{" "}
-          using <code>qyyyy</code> format for quarter (e.g. <code>20254</code>{" "}
-          for F25, <code>20261</code> for W26, <code>20262</code> for S26, etc)
-        </p>
+          <Accordion.Item
+            eventKey="by-quarter-and-subject-area"
+            key="by-quarter-and-subject-area"
+          >
+            <Accordion.Header>
+              Download by Quarter and Subject Area
+            </Accordion.Header>
+            <Accordion.Body>
+              Download classes for a specific subject area and quarter (using{" "}
+              <code>yyyyq</code>). For now, use{" "}
+              <a href="/swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCoursesQuarterAndSubjectArea">
+                this endpoint
+              </a>
+              . Example: quarter <code>20261</code>, subject area{" "}
+              <code>CMPSC</code>.
+            </Accordion.Body>
+          </Accordion.Item>
+        </Accordion>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
+++ b/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
@@ -16,6 +16,24 @@ export default function CSVDownloadsPage() {
     `/api/courses/csv/byQuarterAndSubjectArea?yyyyq=${encodeURIComponent(normalizedQuarter)}` +
     `&subjectArea=${encodeURIComponent(normalizedSubjectArea)}`;
 
+  const downloadCsv = (url) => {
+    window.location.assign(url);
+  };
+
+  const handleQuarterSubmit = (e) => {
+    e.preventDefault();
+    if (isValidQuarter) {
+      downloadCsv(byQuarterUrl);
+    }
+  };
+
+  const handleQuarterSubjectSubmit = (e) => {
+    e.preventDefault();
+    if (isValidQuarter && isValidSubjectArea) {
+      downloadCsv(byQuarterAndSubjectUrl);
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="container mt-3">
@@ -30,7 +48,7 @@ export default function CSVDownloadsPage() {
             </Accordion.Header>
             <Accordion.Body>
 
-              <Form>
+              <Form onSubmit={handleQuarterSubmit}>
                 <Form.Group className="mb-3" controlId="quarterOnly">
                   <Form.Label>Quarter (yyyyq)</Form.Label>
                   <Form.Control
@@ -46,7 +64,7 @@ export default function CSVDownloadsPage() {
                 </Form.Group>
 
                 <Button
-                  onClick={() => window.location.assign(byQuarterUrl)}
+                  type="submit"
                   variant="primary"
                   disabled={!isValidQuarter}
                 >
@@ -64,7 +82,7 @@ export default function CSVDownloadsPage() {
             </Accordion.Header>
             <Accordion.Body>
 
-              <Form>
+              <Form onSubmit={handleQuarterSubjectSubmit}>
                 <Form.Group className="mb-3" controlId="quarterWithSubject">
                   <Form.Label>Quarter (yyyyq)</Form.Label>
                   <Form.Control
@@ -87,7 +105,7 @@ export default function CSVDownloadsPage() {
                 </Form.Group>
 
                 <Button
-                  onClick={() => window.location.assign(byQuarterAndSubjectUrl)}
+                  type="submit"
                   variant="primary"
                   disabled={!isValidQuarter || !isValidSubjectArea}
                 >

--- a/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
+++ b/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
@@ -1,43 +1,89 @@
-import React from "react";
+import React, { useState } from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { Accordion } from "react-bootstrap";
+import { Accordion, Form, Button } from "react-bootstrap";
 
 export default function CSVDownloadsPage() {
+  const [quarter, setQuarter] = useState("");
+  const [subjectArea, setSubjectArea] = useState("");
+
   return (
     <BasicLayout>
       <div className="container mt-3">
         <h1>CSV Downloads</h1>
-        <Accordion>
-          <Accordion.Item eventKey="by-quarter" key="by-quarter">
-            <Accordion.Header>Download all UCSB classes by Quarter</Accordion.Header>
+
+        <Accordion defaultActiveKey="by-quarter" className="mt-3">
+
+          {/* Download by Quarter */}
+          <Accordion.Item eventKey="by-quarter">
+            <Accordion.Header>
+              Download all UCSB classes by Quarter
+            </Accordion.Header>
             <Accordion.Body>
-              Download all classes for a given quarter (in <code>yyyyq</code>{" "}
-              format). For now, use{" "}
-              <a href="/swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCourses">
-                this endpoint
-              </a>
-              . Example quarters: <code>20254</code> (F25), <code>20261</code>{" "}
-              (W26), <code>20262</code> (S26).
+
+              <Form>
+                <Form.Group className="mb-3" controlId="quarterOnly">
+                  <Form.Label>Quarter (yyyyq)</Form.Label>
+                  <Form.Control
+                    type="text"
+                    placeholder="e.g. 20261"
+                    value={quarter}
+                    onChange={(e) => setQuarter(e.target.value)}
+                    pattern="\d{5}"
+                  />
+                  <Form.Text muted>
+                    Example: 20254 (F25), 20261 (W26), 20262 (S26)
+                  </Form.Text>
+                </Form.Group>
+
+                <Button variant="primary" disabled={!quarter}>
+                  Download CSV
+                </Button>
+              </Form>
+
             </Accordion.Body>
           </Accordion.Item>
 
-          <Accordion.Item
-            eventKey="by-quarter-and-subject-area"
-            key="by-quarter-and-subject-area"
-          >
+          {/* Download by Quarter + Subject Area */}
+          <Accordion.Item eventKey="by-quarter-and-subject-area">
             <Accordion.Header>
-              Download by Quarter and Subject Area
+              Download all UCSB classes by Quarter and Subject Area
             </Accordion.Header>
             <Accordion.Body>
-              Download classes for a specific subject area and quarter (using{" "}
-              <code>yyyyq</code>). For now, use{" "}
-              <a href="/swagger-ui/index.html#/API%20for%20course%20data%20as%20CSV%20downloads/csvForCoursesQuarterAndSubjectArea">
-                this endpoint
-              </a>
-              . Example: quarter <code>20261</code>, subject area{" "}
-              <code>CMPSC</code>.
+
+              <Form>
+                <Form.Group className="mb-3" controlId="quarterWithSubject">
+                  <Form.Label>Quarter (yyyyq)</Form.Label>
+                  <Form.Control
+                    type="text"
+                    placeholder="e.g. 20261"
+                    value={quarter}
+                    onChange={(e) => setQuarter(e.target.value)}
+                    pattern="\d{5}"
+                  />
+                </Form.Group>
+
+                <Form.Group className="mb-3" controlId="subjectArea">
+                  <Form.Label>Subject Area</Form.Label>
+                  <Form.Control
+                    type="text"
+                    placeholder="e.g. CMPSC"
+                    value={subjectArea}
+                    onChange={(e) => setSubjectArea(e.target.value)}
+                  />
+                </Form.Group>
+
+                <Button
+                  variant="primary"
+                  disabled={!quarter || !subjectArea}
+                >
+                  Download CSV
+                </Button>
+
+              </Form>
+
             </Accordion.Body>
           </Accordion.Item>
+
         </Accordion>
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
+++ b/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
@@ -5,6 +5,16 @@ import { Accordion, Form, Button } from "react-bootstrap";
 export default function CSVDownloadsPage() {
   const [quarter, setQuarter] = useState("");
   const [subjectArea, setSubjectArea] = useState("");
+  const normalizedQuarter = quarter.trim();
+  const normalizedSubjectArea = subjectArea.trim().toUpperCase();
+
+  const isValidQuarter = /^\d{5}$/.test(normalizedQuarter);
+  const isValidSubjectArea = normalizedSubjectArea.length > 0;
+
+  const byQuarterUrl = `/api/courses/csv/quarter?yyyyq=${encodeURIComponent(normalizedQuarter)}`;
+  const byQuarterAndSubjectUrl =
+    `/api/courses/csv/byQuarterAndSubjectArea?yyyyq=${encodeURIComponent(normalizedQuarter)}` +
+    `&subjectArea=${encodeURIComponent(normalizedSubjectArea)}`;
 
   return (
     <BasicLayout>
@@ -35,7 +45,11 @@ export default function CSVDownloadsPage() {
                   </Form.Text>
                 </Form.Group>
 
-                <Button variant="primary" disabled={!quarter}>
+                <Button
+                  onClick={() => window.location.assign(byQuarterUrl)}
+                  variant="primary"
+                  disabled={!isValidQuarter}
+                >
                   Download CSV
                 </Button>
               </Form>
@@ -73,8 +87,9 @@ export default function CSVDownloadsPage() {
                 </Form.Group>
 
                 <Button
+                  onClick={() => window.location.assign(byQuarterAndSubjectUrl)}
                   variant="primary"
-                  disabled={!quarter || !subjectArea}
+                  disabled={!isValidQuarter || !isValidSubjectArea}
                 >
                   Download CSV
                 </Button>

--- a/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
+++ b/frontend/src/main/pages/CSV/CSVDownloadsPage.jsx
@@ -40,14 +40,12 @@ export default function CSVDownloadsPage() {
         <h1>CSV Downloads</h1>
 
         <Accordion defaultActiveKey="by-quarter" className="mt-3">
-
           {/* Download by Quarter */}
           <Accordion.Item eventKey="by-quarter">
             <Accordion.Header>
               Download all UCSB classes by Quarter
             </Accordion.Header>
             <Accordion.Body>
-
               <Form onSubmit={handleQuarterSubmit}>
                 <Form.Group className="mb-3" controlId="quarterOnly">
                   <Form.Label>Quarter (yyyyq)</Form.Label>
@@ -71,7 +69,6 @@ export default function CSVDownloadsPage() {
                   Download CSV
                 </Button>
               </Form>
-
             </Accordion.Body>
           </Accordion.Item>
 
@@ -81,7 +78,6 @@ export default function CSVDownloadsPage() {
               Download all UCSB classes by Quarter and Subject Area
             </Accordion.Header>
             <Accordion.Body>
-
               <Form onSubmit={handleQuarterSubjectSubmit}>
                 <Form.Group className="mb-3" controlId="quarterWithSubject">
                   <Form.Label>Quarter (yyyyq)</Form.Label>
@@ -111,12 +107,9 @@ export default function CSVDownloadsPage() {
                 >
                   Download CSV
                 </Button>
-
               </Form>
-
             </Accordion.Body>
           </Accordion.Item>
-
         </Accordion>
       </div>
     </BasicLayout>

--- a/frontend/src/stories/pages/CSV/CSVDownloadsPage.stories.jsx
+++ b/frontend/src/stories/pages/CSV/CSVDownloadsPage.stories.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
+
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "pages/CSV/CSVDownloadsPage",
+  component: CSVDownloadsPage,
+};
+
+const Template = () => <CSVDownloadsPage />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingBoth, {
+        status: 200,
+      });
+    }),
+    http.get("/api/currentUser", () => {
+      return HttpResponse.status(403); // returns 403 when not logged in
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -25,6 +25,15 @@ describe("AppNavbar tests", () => {
     expect(
       await screen.findByText("Welcome, pconrad.cis@gmail.com"),
     ).toBeInTheDocument();
+
+    expect(screen.getByTestId("appnavbar-downloads")).toBeInTheDocument();
+    expect(screen.getByTestId("appnavbar-downloads")).toHaveAttribute(
+      "href",
+      "/downloads",
+    );
+    expect(screen.getByTestId("appnavbar-downloads")).toHaveTextContent(
+      "Downloads",
+    );
   });
 
   test("renders correctly for admin user", async () => {

--- a/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
+++ b/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
+
+describe("CSVDownloadsPage tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CSVDownloadsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("CSV Downloads")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
+++ b/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
@@ -6,6 +6,13 @@ import { MemoryRouter } from "react-router-dom";
 import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
 
 describe("CSVDownloadsPage tests", () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    delete window.location;
+    window.location = originalLocation;
+  });
+
   const renderPage = () => {
     const queryClient = new QueryClient();
 
@@ -54,5 +61,75 @@ describe("CSVDownloadsPage tests", () => {
     });
 
     expect(byQuarterAndSubjectButton).not.toBeDisabled();
+  });
+
+  test("submitting by-quarter form only downloads when quarter is valid", () => {
+    const assignMock = vi.fn();
+    delete window.location;
+    window.location = Object.assign(new URL("http://localhost:3000"), {
+      assign: assignMock,
+    });
+
+    renderPage();
+
+    const byQuarterButton = screen.getAllByRole("button", {
+      name: "Download CSV",
+    })[0];
+    const byQuarterForm = byQuarterButton.closest("form");
+
+    fireEvent.submit(byQuarterForm);
+    expect(assignMock).not.toHaveBeenCalled();
+
+    const quarterInputs = screen.getAllByLabelText("Quarter (yyyyq)");
+    fireEvent.change(quarterInputs[0], { target: { value: " 20261 " } });
+
+    fireEvent.click(byQuarterButton);
+
+    expect(assignMock).toHaveBeenCalledTimes(1);
+    expect(assignMock).toHaveBeenCalledWith(
+      "/api/courses/csv/quarter?yyyyq=20261",
+    );
+  });
+
+  test("submitting by-quarter-and-subject form requires valid quarter and subject", () => {
+    const assignMock = vi.fn();
+    delete window.location;
+    window.location = Object.assign(new URL("http://localhost:3000"), {
+      assign: assignMock,
+    });
+
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Download all UCSB classes by Quarter and Subject Area",
+      }),
+    );
+
+    const allDownloadButtons = screen.getAllByRole("button", {
+      name: "Download CSV",
+    });
+    const byQuarterAndSubjectButton = allDownloadButtons[1];
+    const byQuarterAndSubjectForm = byQuarterAndSubjectButton.closest("form");
+
+    fireEvent.submit(byQuarterAndSubjectForm);
+    expect(assignMock).not.toHaveBeenCalled();
+
+    const quarterInputs = screen.getAllByLabelText("Quarter (yyyyq)");
+    fireEvent.change(quarterInputs[1], { target: { value: "20261" } });
+
+    fireEvent.submit(byQuarterAndSubjectForm);
+    expect(assignMock).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText("Subject Area"), {
+      target: { value: " cmpsc " },
+    });
+
+    fireEvent.click(byQuarterAndSubjectButton);
+
+    expect(assignMock).toHaveBeenCalledTimes(1);
+    expect(assignMock).toHaveBeenCalledWith(
+      "/api/courses/csv/byQuarterAndSubjectArea?yyyyq=20261&subjectArea=CMPSC",
+    );
   });
 });

--- a/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
+++ b/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -25,79 +24,70 @@ describe("CSVDownloadsPage tests", () => {
     );
   };
 
+  const mockLocationAssign = () => {
+    const assignMock = vi.fn();
+    delete window.location;
+    window.location = Object.assign(new URL("http://localhost:3000"), {
+      assign: assignMock,
+    });
+    return assignMock;
+  };
+
   test("renders correctly", async () => {
     renderPage();
 
     expect(await screen.findByText("CSV Downloads")).toBeInTheDocument();
   });
 
-  test("download links are enabled only for valid input", async () => {
+  test("quarter input must be exactly five digits to enable by-quarter download", async () => {
     renderPage();
 
+    const quarterInput = screen.getAllByLabelText("Quarter (yyyyq)")[0];
     const byQuarterButton = screen.getAllByRole("button", {
       name: "Download CSV",
     })[0];
+
+    expect(quarterInput).toHaveValue("");
     expect(byQuarterButton).toBeDisabled();
 
-    const quarterInputs = screen.getAllByLabelText("Quarter (yyyyq)");
-    fireEvent.change(quarterInputs[0], { target: { value: "20261" } });
+    fireEvent.change(quarterInput, { target: { value: "20241x" } });
+    expect(quarterInput).toHaveValue("20241x");
+    expect(byQuarterButton).toBeDisabled();
 
+    fireEvent.change(quarterInput, { target: { value: "x20241" } });
+    expect(quarterInput).toHaveValue("x20241");
+    expect(byQuarterButton).toBeDisabled();
+
+    fireEvent.change(quarterInput, { target: { value: "20241" } });
+    expect(quarterInput).toHaveValue("20241");
     expect(byQuarterButton).not.toBeDisabled();
-
-    userEvent.click(
-      screen.getByRole("button", {
-        name: "Download all UCSB classes by Quarter and Subject Area",
-      }),
-    );
-
-    const allDownloadButtons = screen.getAllByRole("button", {
-      name: "Download CSV",
-    });
-    const byQuarterAndSubjectButton = allDownloadButtons[1];
-    expect(byQuarterAndSubjectButton).toBeDisabled();
-
-    fireEvent.change(screen.getByLabelText("Subject Area"), {
-      target: { value: "cmpsc" },
-    });
-
-    expect(byQuarterAndSubjectButton).not.toBeDisabled();
   });
 
   test("submitting by-quarter form only downloads when quarter is valid", () => {
-    const assignMock = vi.fn();
-    delete window.location;
-    window.location = Object.assign(new URL("http://localhost:3000"), {
-      assign: assignMock,
-    });
-
+    const assignMock = mockLocationAssign();
     renderPage();
 
+    const quarterInput = screen.getAllByLabelText("Quarter (yyyyq)")[0];
     const byQuarterButton = screen.getAllByRole("button", {
       name: "Download CSV",
     })[0];
     const byQuarterForm = byQuarterButton.closest("form");
 
+    fireEvent.change(quarterInput, { target: { value: "20241x" } });
     fireEvent.submit(byQuarterForm);
     expect(assignMock).not.toHaveBeenCalled();
 
-    const quarterInputs = screen.getAllByLabelText("Quarter (yyyyq)");
-    fireEvent.change(quarterInputs[0], { target: { value: " 20261 " } });
-
-    fireEvent.click(byQuarterButton);
+    fireEvent.change(quarterInput, { target: { value: " 20241 " } });
+    fireEvent.submit(byQuarterForm);
 
     expect(assignMock).toHaveBeenCalledTimes(1);
     expect(assignMock).toHaveBeenCalledWith(
-      "/api/courses/csv/quarter?yyyyq=20261",
+      "/api/courses/csv/quarter?yyyyq=20241",
     );
   });
 
   test("submitting by-quarter-and-subject form requires valid quarter and subject", () => {
-    const assignMock = vi.fn();
-    delete window.location;
-    window.location = Object.assign(new URL("http://localhost:3000"), {
-      assign: assignMock,
-    });
-
+    const assignMock = mockLocationAssign();
     renderPage();
 
     fireEvent.click(
@@ -112,24 +102,35 @@ describe("CSVDownloadsPage tests", () => {
     const byQuarterAndSubjectButton = allDownloadButtons[1];
     const byQuarterAndSubjectForm = byQuarterAndSubjectButton.closest("form");
 
+    const quarterInput = screen.getAllByLabelText("Quarter (yyyyq)")[1];
+    const subjectAreaInput = screen.getByLabelText("Subject Area");
+
+    expect(subjectAreaInput).toHaveValue("");
+    expect(byQuarterAndSubjectButton).toBeDisabled();
+
+    fireEvent.change(quarterInput, { target: { value: "20241" } });
+    expect(byQuarterAndSubjectButton).toBeDisabled();
     fireEvent.submit(byQuarterAndSubjectForm);
     expect(assignMock).not.toHaveBeenCalled();
 
-    const quarterInputs = screen.getAllByLabelText("Quarter (yyyyq)");
-    fireEvent.change(quarterInputs[1], { target: { value: "20261" } });
-
+    fireEvent.change(quarterInput, { target: { value: "20241x" } });
+    fireEvent.change(subjectAreaInput, { target: { value: "cmpsc" } });
+    expect(byQuarterAndSubjectButton).toBeDisabled();
     fireEvent.submit(byQuarterAndSubjectForm);
     expect(assignMock).not.toHaveBeenCalled();
 
-    fireEvent.change(screen.getByLabelText("Subject Area"), {
+    fireEvent.change(quarterInput, { target: { value: " 20241 " } });
+
+    fireEvent.change(subjectAreaInput, {
       target: { value: " cmpsc " },
     });
 
-    fireEvent.click(byQuarterAndSubjectButton);
+    expect(byQuarterAndSubjectButton).not.toBeDisabled();
+    fireEvent.submit(byQuarterAndSubjectForm);
 
     expect(assignMock).toHaveBeenCalledTimes(1);
     expect(assignMock).toHaveBeenCalledWith(
-      "/api/courses/csv/byQuarterAndSubjectArea?yyyyq=20261&subjectArea=CMPSC",
+      "/api/courses/csv/byQuarterAndSubjectArea?yyyyq=20241&subjectArea=CMPSC",
     );
   });
 });

--- a/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
+++ b/frontend/src/tests/pages/CSV/CSVDownloads.test.jsx
@@ -1,13 +1,14 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import CSVDownloadsPage from "main/pages/CSV/CSVDownloadsPage";
 
 describe("CSVDownloadsPage tests", () => {
-  const queryClient = new QueryClient();
+  const renderPage = () => {
+    const queryClient = new QueryClient();
 
-  test("renders correctly", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -15,7 +16,43 @@ describe("CSVDownloadsPage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
+  };
+
+  test("renders correctly", async () => {
+    renderPage();
 
     expect(await screen.findByText("CSV Downloads")).toBeInTheDocument();
+  });
+
+  test("download links are enabled only for valid input", async () => {
+    renderPage();
+
+    const byQuarterButton = screen.getAllByRole("button", {
+      name: "Download CSV",
+    })[0];
+    expect(byQuarterButton).toBeDisabled();
+
+    const quarterInputs = screen.getAllByLabelText("Quarter (yyyyq)");
+    fireEvent.change(quarterInputs[0], { target: { value: "20261" } });
+
+    expect(byQuarterButton).not.toBeDisabled();
+
+    userEvent.click(
+      screen.getByRole("button", {
+        name: "Download all UCSB classes by Quarter and Subject Area",
+      }),
+    );
+
+    const allDownloadButtons = screen.getAllByRole("button", {
+      name: "Download CSV",
+    });
+    const byQuarterAndSubjectButton = allDownloadButtons[1];
+    expect(byQuarterAndSubjectButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Subject Area"), {
+      target: { value: "cmpsc" },
+    });
+
+    expect(byQuarterAndSubjectButton).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
In this PR, I added a new downloads page so users can export course data as CSVs with these filters:
- by quarter
- by quarter + subject area

### UI Comparison

NavBar:
<img width="478" height="112" alt="Screenshot 2026-03-03 at 10 21 10 AM" src="https://github.com/user-attachments/assets/f5ca4b5c-e1dc-410d-98a7-3bae08ac54e4" /><img width="478" height="112" alt="Screenshot 2026-03-03 at 10 20 56 AM" src="https://github.com/user-attachments/assets/9683fc0d-8321-41eb-bf1a-d632c2655bfb" />

Downloads Page:
<img width="1458" alt="Screenshot 2026-03-03 at 9 55 39 AM" src="https://github.com/user-attachments/assets/03e748c9-62e1-49fb-9ee9-3c7128c1e438" />

## Testing Plan
1. Open up the [deployed site](https://courses-dev-rachit182.dokku-00.cs.ucsb.edu). 
2. Run Downloads by Quarter & Quarter+Subject.
_**Note:** the connected db only has 20253 through 20261 data for testing._
3. Verify that the downloaded file is correct.

Deployed at: [https://courses-dev-rachit182.dokku-00.cs.ucsb.edu/](https://courses-dev-rachit182.dokku-00.cs.ucsb.edu)

Closes #265  

