### PR TITLE
Embedded MongoDB Version Bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
-            <version>4.18.0</version>
+            <version>4.24.0</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
In this PR, we bump `de.flapdoodle.embed.mongo.spring3x` from `4.18.0` -> `4.24.0` to hopefully resolve the Fedora Linux db-resolution problems.

See here: 
* https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/557
* https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/468

This will be tested with a student running Fedora Linux prior to deployment.
Notably, there is a workaround listed in 468; If this doesn't resolve the issue, that may work. However, we should certainly test that out on MacOS prior to deployment.

Deployed to: https://courses-qa.dokku-00.cs.ucsb.edu/
