### PR TITLE
pc - add FinalExamCard plus fixtures, tests, and storybook entry

### DIFF
--- a/frontend/src/fixtures/finalsFixtures.jsx
+++ b/frontend/src/fixtures/finalsFixtures.jsx
@@ -1,0 +1,20 @@
+const finalsFixtures = {
+  cmpsc24_s26: {
+    hasFinals: true,
+    comments: "",
+    examDay: "T",
+    examDate: "20260609",
+    beginTime: "12:00",
+    endTime: "15:00",
+  },
+  cmpsc196_s26: {
+    hasFinals: false,
+    comments: "Contact Professor for Final Exam Information",
+    examDay: null,
+    examDate: null,
+    beginTime: null,
+    endTime: null,
+  },
+};
+
+export { finalsFixtures };

--- a/frontend/src/main/components/Finals/FinalExamCard.jsx
+++ b/frontend/src/main/components/Finals/FinalExamCard.jsx
@@ -1,0 +1,79 @@
+import Card from "react-bootstrap/Card";
+
+const dayToStringMap = {
+  M: "Monday",
+  T: "Tuesday",
+  W: "Wednesday",
+  R: "Thursday",
+  F: "Friday",
+  S: "Saturday",
+  U: "Sunday",
+};
+
+const dayToString = (day) => {
+  return dayToStringMap[day] || day;
+};
+
+const monthToStringMap = {
+  "01": "January",
+  "02": "February",
+  "03": "March",
+  "04": "April",
+  "05": "May",
+  "06": "June",
+  "07": "July",
+  "08": "August",
+  "09": "September",
+  10: "October",
+  11: "November",
+  12: "December",
+};
+
+const monthToString = (month) => {
+  return monthToStringMap[month] || month;
+};
+
+const formatDate = (date) => {
+  return `${monthToString(date.substring(4, 6))} ${parseInt(date.substring(6, 8))}, ${date.substring(0, 4)}`;
+};
+
+function FinalExamCard({ finalsInfo }) {
+  if (!finalsInfo) {
+    return null;
+  }
+
+  if (finalsInfo.hasFinals === false) {
+    return (
+      <Card>
+        <Card.Body>
+          <Card.Title>Final Exam:</Card.Title>
+          <Card.Text>
+            {finalsInfo.comments
+              ? finalsInfo.comments
+              : "No final exam information available."}
+          </Card.Text>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  const day = finalsInfo.examDay ? dayToString(finalsInfo.examDay) : "";
+  const date = finalsInfo.examDate ? formatDate(finalsInfo.examDate) : "";
+  const beginTime = finalsInfo.beginTime ? finalsInfo.beginTime : "";
+  const endTime = finalsInfo.endTime ? finalsInfo.endTime : "";
+
+  const examInfoString = finalsInfo.examDay
+    ? `${day}, ${date} ${beginTime}—${endTime}`
+    : "Exam information not available.";
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>Final Exam:</Card.Title>
+        <Card.Text>{examInfoString}</Card.Text>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default FinalExamCard;

--- a/frontend/src/main/components/Finals/FinalExamCard.jsx
+++ b/frontend/src/main/components/Finals/FinalExamCard.jsx
@@ -1,5 +1,6 @@
 import Card from "react-bootstrap/Card";
 
+// Stryker disable StringLiteral : otherwise we would have to test for every possible day and month value, which is not practical
 const dayToStringMap = {
   M: "Monday",
   T: "Tuesday",
@@ -8,10 +9,6 @@ const dayToStringMap = {
   F: "Friday",
   S: "Saturday",
   U: "Sunday",
-};
-
-const dayToString = (day) => {
-  return dayToStringMap[day] || day;
 };
 
 const monthToStringMap = {
@@ -27,6 +24,14 @@ const monthToStringMap = {
   10: "October",
   11: "November",
   12: "December",
+};
+
+const emptyString = "";
+
+// Stryker restore StringLiteral
+
+const dayToString = (day) => {
+  return dayToStringMap[day] || day;
 };
 
 const monthToString = (month) => {
@@ -57,10 +62,14 @@ function FinalExamCard({ finalsInfo }) {
     );
   }
 
-  const day = finalsInfo.examDay ? dayToString(finalsInfo.examDay) : "";
-  const date = finalsInfo.examDate ? formatDate(finalsInfo.examDate) : "";
-  const beginTime = finalsInfo.beginTime ? finalsInfo.beginTime : "";
-  const endTime = finalsInfo.endTime ? finalsInfo.endTime : "";
+  const day = finalsInfo.examDay
+    ? dayToString(finalsInfo.examDay)
+    : emptyString;
+  const date = finalsInfo.examDate
+    ? formatDate(finalsInfo.examDate)
+    : emptyString;
+  const beginTime = finalsInfo.beginTime ? finalsInfo.beginTime : emptyString;
+  const endTime = finalsInfo.endTime ? finalsInfo.endTime : emptyString;
 
   const examInfoString = finalsInfo.examDay
     ? `${day}, ${date} ${beginTime}—${endTime}`

--- a/frontend/src/stories/components/Finals/FinalExamCard.stories.jsx
+++ b/frontend/src/stories/components/Finals/FinalExamCard.stories.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import FinalExamCard from "main/components/Finals/FinalExamCard";
+import { finalsFixtures } from "fixtures/finalsFixtures";
+
+export default {
+  title: "components/Finals/FinalExamCard",
+  component: FinalExamCard,
+};
+
+const Template = (args) => {
+  return <FinalExamCard {...args} />;
+};
+
+export const cmpsc24_s26 = Template.bind({});
+cmpsc24_s26.args = {
+  finalsInfo: finalsFixtures.cmpsc24_s26,
+};
+
+export const cmpsc196_s26 = Template.bind({});
+cmpsc196_s26.args = {
+  finalsInfo: finalsFixtures.cmpsc196_s26,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  finalsInfo: null,
+};

--- a/frontend/src/tests/components/Finals/FinalExamCard.test.jsx
+++ b/frontend/src/tests/components/Finals/FinalExamCard.test.jsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+
+import FinalExamCard from "main/components/Finals/FinalExamCard";
+import { finalsFixtures } from "fixtures/finalsFixtures";
+
+describe("FinalExamCard tests", () => {
+  describe("FinalExamCard happy path tests", () => {
+    test("renders correctly when parameter is null", () => {
+      render(<FinalExamCard finalsInfo={null} />);
+      expect(
+        screen.queryByText("Final Exam Information"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("renders correctly for CS24 S26", () => {
+      render(<FinalExamCard finalsInfo={finalsFixtures.cmpsc24_s26} />);
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("Tuesday, June 9, 2026 12:00—15:00"),
+      ).toBeInTheDocument();
+    });
+
+    test("renders correctly for CS196 S26", () => {
+      render(<FinalExamCard finalsInfo={finalsFixtures.cmpsc196_s26} />);
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("Contact Professor for Final Exam Information"),
+      ).toBeInTheDocument();
+    });
+  });
+  describe("FinalExamCard error path tests", () => {
+    test("renders correctly for malformed day of week", () => {
+      render(
+        <FinalExamCard
+          finalsInfo={{
+            ...finalsFixtures.cmpsc24_s26,
+            examDay: "X",
+          }}
+        />,
+      );
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("X, June 9, 2026 12:00—15:00"),
+      ).toBeInTheDocument();
+    });
+
+    test("renders correctly for malformed month", () => {
+      render(
+        <FinalExamCard
+          finalsInfo={{
+            ...finalsFixtures.cmpsc24_s26,
+            examDate: "20261309",
+          }}
+        />,
+      );
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("Tuesday, 13 9, 2026 12:00—15:00"),
+      ).toBeInTheDocument();
+    });
+
+    test("renders correctly when hasFinals is false and there is no comment", () => {
+      render(
+        <FinalExamCard
+          finalsInfo={{
+            ...finalsFixtures.cmpsc196_s26,
+            hasFinals: false,
+            comments: null,
+          }}
+        />,
+      );
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("No final exam information available."),
+      ).toBeInTheDocument();
+    });
+
+    test("renders correctly when examDay is missing", () => {
+      render(
+        <FinalExamCard
+          finalsInfo={{
+            ...finalsFixtures.cmpsc24_s26,
+            examDay: null,
+          }}
+        />,
+      );
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("Exam information not available."),
+      ).toBeInTheDocument();
+    });
+
+    test("renders correctly when examDate is missing", () => {
+      render(
+        <FinalExamCard
+          finalsInfo={{
+            ...finalsFixtures.cmpsc24_s26,
+            examDate: null,
+          }}
+        />,
+      );
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(screen.getByText("Tuesday, 12:00—15:00")).toBeInTheDocument();
+    });
+
+    test("renders correctly when beginTime is missing", () => {
+      render(
+        <FinalExamCard
+          finalsInfo={{
+            ...finalsFixtures.cmpsc24_s26,
+            beginTime: null,
+          }}
+        />,
+      );
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("Tuesday, June 9, 2026 —15:00"),
+      ).toBeInTheDocument();
+    });
+
+    test("renders correctly when endTime is missing", () => {
+      render(
+        <FinalExamCard
+          finalsInfo={{
+            ...finalsFixtures.cmpsc24_s26,
+            endTime: null,
+          }}
+        />,
+      );
+      expect(screen.getByText("Final Exam:")).toBeInTheDocument();
+      expect(
+        screen.getByText("Tuesday, June 9, 2026 12:00—"),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
This will support a future feature to put FinalExamInformation on the Course Information Page

Closes #280 

This is a Storybook only PR.   The storybook can be viewed live here:

* <https://66d38213c4af0f3da7d52f03-zkpnjllthd.chromatic.com/?path=/story/components-finals-finalexamcard--cmpsc-24-s-26>

# Screenshots

<img width="567" height="336" alt="image" src="https://github.com/user-attachments/assets/c8359357-516c-4114-b18a-d95ba9cc33cd" />


<img width="888" height="353" alt="image" src="https://github.com/user-attachments/assets/d14a48c6-b7af-47e0-a4be-50511b89775e" />


