### PR TITLE
Pc add finals info to course page

### DIFF
--- a/frontend/src/main/components/Finals/FinalExamCard.jsx
+++ b/frontend/src/main/components/Finals/FinalExamCard.jsx
@@ -42,14 +42,15 @@ const formatDate = (date) => {
   return `${monthToString(date.substring(4, 6))} ${parseInt(date.substring(6, 8))}, ${date.substring(0, 4)}`;
 };
 
-function FinalExamCard({ finalsInfo }) {
+// cardProps can be used to pass additional props to the Card component, such as styling or className
+function FinalExamCard({ finalsInfo, cardProps = {} }) {
   if (!finalsInfo) {
     return null;
   }
 
   if (finalsInfo.hasFinals === false) {
     return (
-      <Card>
+      <Card {...cardProps}>
         <Card.Body>
           <Card.Title>Final Exam:</Card.Title>
           <Card.Text>
@@ -76,7 +77,7 @@ function FinalExamCard({ finalsInfo }) {
     : "Exam information not available.";
 
   return (
-    <Card>
+    <Card {...cardProps}>
       <Card.Body>
         <Card.Title>Final Exam:</Card.Title>
         <Card.Text>{examInfoString}</Card.Text>

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.jsx
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.jsx
@@ -79,7 +79,10 @@ export default function CourseDetailsIndexPage() {
             Course Details for {moreDetails.courseId} {yyyyqToQyy(qtr)}
           </h5>
         )}
-        <FinalExamCard finalsInfo={finalsInfo} />
+        <FinalExamCard
+          finalsInfo={finalsInfo}
+          cardProps={{ className: "py-1 my-4" }}
+        />
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.jsx
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.jsx
@@ -6,6 +6,7 @@ import CourseDetailsTable from "main/components/CourseDetails/CourseDetailsTable
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import CourseDescriptionTable from "main/components/Courses/CourseDescriptionTable";
 import GradeHistoryGraphs from "main/components/GradeHistory/GradeHistoryGraph";
+import FinalExamCard from "main/components/Finals/FinalExamCard";
 
 export default function CourseDetailsIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -27,6 +28,22 @@ export default function CourseDetailsIndexPage() {
     },
   );
 
+  const {
+    data: finalsInfo,
+    _errorFinalsInfo,
+    _statusFinalsInfo,
+  } = useBackend(
+    // Stryker disable all : hard to test for query caching
+    [`/api/public/finalsInfo?quarterYYYYQ=${qtr}&enrollCd=${enrollCode}`],
+    {
+      method: "GET",
+      url: `/api/public/finalsInfo`,
+      params: {
+        quarterYYYYQ: qtr,
+        enrollCd: enrollCode,
+      },
+    },
+  );
   const courseId = moreDetails?.courseId.trim() || "";
 
   let subjectArea = "";
@@ -62,6 +79,7 @@ export default function CourseDetailsIndexPage() {
             Course Details for {moreDetails.courseId} {yyyyqToQyy(qtr)}
           </h5>
         )}
+        <FinalExamCard finalsInfo={finalsInfo} />
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}

--- a/frontend/src/stories/pages/CourseDetails/CourseDetailsIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/CourseDetails/CourseDetailsIndexPage.stories.jsx
@@ -10,6 +10,7 @@ import { oneQuarterCourse } from "fixtures/gradeHistoryFixtures";
 import { http, HttpResponse } from "msw";
 
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { finalsFixtures } from "fixtures/finalsFixtures";
 
 export default {
   title: "pages/CourseDetails/CourseDetailsIndexPage",
@@ -55,6 +56,11 @@ Default.parameters = {
     }),
     http.get("/api/gradehistory/search", () => {
       return HttpResponse.json(oneQuarterCourse, {
+        status: 200,
+      });
+    }),
+    http.get("/api/public/finalsInfo", () => {
+      return HttpResponse.json(finalsFixtures.cmpsc24_s26, {
         status: 200,
       });
     }),


### PR DESCRIPTION
Closes #282 

In this PR, we put final exam information on the course page.

It is deployed to qa here: 
*  <https://courses-qa2.dokku-00.cs.ucsb.edu>

# To test

* Search for some courses for S26, M26 and F26.  Include some courses that have finals, and some that don't such as independent study courses.
* For each, look at the info page and make sure the final exam information looks reasonable.

# Screenshots

## Before

<img width="1118" height="305" alt="image" src="https://github.com/user-attachments/assets/de729f72-ae76-4c81-a985-177591f8b078" />

## After

<img width="1332" height="398" alt="image" src="https://github.com/user-attachments/assets/b1872572-15f4-4020-ad06-b967769a0dc0" />


