### PR TITLE
Creating a simple SecurityFilterChain for Unit Testing

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/courses/config/SecurityConfig.java
@@ -51,8 +51,7 @@ public class SecurityConfig {
 
   @Autowired UserRepository userRepository;
 
-  @Autowired(required = false)
-  RateLimitFilter rateLimitFilter;
+  @Autowired RateLimitFilter rateLimitFilter;
 
   // https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
   @Bean
@@ -70,9 +69,7 @@ public class SecurityConfig {
                     .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                     .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
         .addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class);
-    if (rateLimitFilter != null) {
-      http.addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class);
-    }
+    http.addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class);
     http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
         .logout(
             logout ->

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CSRFControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CSRFControllerTests.java
@@ -4,22 +4,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.config.RateLimitConfig;
+import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
-import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ActiveProfiles("development")
 @WebMvcTest(controllers = CSRFController.class)
-@Import(TestConfig.class)
-public class CSRFControllerTests extends ControllerTestCase {
+@Import({SecurityConfig.class, RateLimitConfig.class})
+public class CSRFControllerTests {
 
   @MockBean UserRepository userRepository;
+
+  @Autowired private MockMvc mockMvc;
 
   @Test
   public void csrf_returns_ok() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -8,8 +8,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
-import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
@@ -21,14 +21,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(value = CourseOverTimeBuildingController.class)
-@Import(SecurityConfig.class)
-public class CourseOverTimeBuildingControllerTests {
+public class CourseOverTimeBuildingControllerTests extends ControllerTestCase {
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -8,8 +8,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
-import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
@@ -20,14 +20,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(value = CourseOverTimeController.class)
-@Import(SecurityConfig.class)
-public class CourseOverTimeControllerTests {
+public class CourseOverTimeControllerTests extends ControllerTestCase {
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
@@ -8,8 +8,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
-import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
@@ -21,14 +21,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(value = CourseOverTimeInstructorController.class)
-@Import(SecurityConfig.class)
-public class CourseOverTimeInstructorControllerTests {
+public class CourseOverTimeInstructorControllerTests extends ControllerTestCase {
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.ControllerTestCase;
-import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
@@ -19,13 +18,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(value = UCSBAPIQuarterController.class)
-@Import(SecurityConfig.class)
 public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
 
   @MockBean UserRepository userRepository;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.ControllerTestCase;
-import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.Primary;
@@ -19,12 +18,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(value = UCSBCurriculumController.class)
-@Import(SecurityConfig.class)
 public class UCSBCurriculumControllerTests extends ControllerTestCase {
 
   @MockBean UserRepository userRepository;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
@@ -7,20 +7,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(value = UCSBSectionsController.class)
-@Import(SecurityConfig.class)
-public class UCSBSectionsControllerTests {
+public class UCSBSectionsControllerTests extends ControllerTestCase {
   private ObjectMapper mapper = new ObjectMapper();
 
   @MockBean UserRepository userRepository;

--- a/src/test/java/edu/ucsb/cs156/courses/integration/AsyncJobTestsIT.java
+++ b/src/test/java/edu/ucsb/cs156/courses/integration/AsyncJobTestsIT.java
@@ -7,17 +7,14 @@ import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.services.jobs.JobContextFactory;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
-import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import edu.ucsb.cs156.courses.testconfig.TestJob;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@Import(TestConfig.class)
 public class AsyncJobTestsIT {
 
   @Autowired private JobService jobService;

--- a/src/test/java/edu/ucsb/cs156/courses/testconfig/TestConfig.java
+++ b/src/test/java/edu/ucsb/cs156/courses/testconfig/TestConfig.java
@@ -1,14 +1,18 @@
 package edu.ucsb.cs156.courses.testconfig;
 
-import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.services.CurrentUserService;
 import edu.ucsb.cs156.courses.services.GrantedAuthoritiesService;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 
 @TestConfiguration
-@Import(SecurityConfig.class)
+@EnableMethodSecurity
+@EnableWebSecurity
 public class TestConfig {
 
   @Bean
@@ -19,5 +23,12 @@ public class TestConfig {
   @Bean
   public GrantedAuthoritiesService grantedAuthoritiesService() {
     return new GrantedAuthoritiesService();
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    return http.exceptionHandling(
+            handling -> handling.authenticationEntryPoint(new Http403ForbiddenEntryPoint()))
+        .build();
   }
 }


### PR DESCRIPTION
In this PR, I add a simple SecurityFilterChain for unit testing. I have integrated it into `TestConfiguration` with `@EnableMethodSecurity` and `@EnableWebSecurity` to allow us to properly test our `PreAuthorize` and `PostAuthorize` annotations without running into filtering limits during testing or having a conditional autowire in the production `SecurityConfiguration`.

Because of this, I have to standardize a few test files that should extend `ControllerTestCase`.

Deployed to https://courses-qa1.dokku-00.cs.ucsb.edu/
