### PR TITLE
Properly Isolating AsyncJobTestsIT

### DIFF
--- a/src/test/java/edu/ucsb/cs156/courses/integration/AsyncJobTestsIT.java
+++ b/src/test/java/edu/ucsb/cs156/courses/integration/AsyncJobTestsIT.java
@@ -4,20 +4,20 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.jobs.ScheduledJobs;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.services.jobs.JobContextFactory;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
-import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import edu.ucsb.cs156.courses.testconfig.TestJob;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@Import(TestConfig.class)
+@ActiveProfiles("integration")
 public class AsyncJobTestsIT {
 
   @Autowired private JobService jobService;
@@ -25,6 +25,8 @@ public class AsyncJobTestsIT {
   @Autowired private JobContextFactory contextFactory;
 
   @MockitoBean private JobsRepository jobsRepository;
+
+  @MockitoBean private ScheduledJobs scheduledJobs;
 
   @Test
   void async_job_actually_runs_asynchronously() {

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -1,0 +1,4 @@
+de.flapdoodle.mongodb.embedded.version=7.0.12
+spring.datasource.url=jdbc:h2:mem:${random.uuid}
+spring.datasource.username=sa
+spring.datasource.password=password


### PR DESCRIPTION
In this PR, I isolate `AsyncJobTestsIT` by adding a `MockitoBean` version of `ScheduledJobs`, applying an `ActiveProfiles` tag, and adding a test properties file instructing the application to use an in-memory h2 instance.
