### PR TITLE
HOTFIX: pc - increase bucket sizes for ip rate limits to 500 initially refreshing at 250 per minute

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,8 +32,8 @@ app.endQtrYYYYQ=${END_QTR:${env.END_QTR:20222}}
 app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}
 app.courseDataStaleThresholdMinutes=${COURSE_DATA_STALE_THRESHOLD_MINUTES:${env.COURSE_DATA_STALE_THRESHOLD_MINUTES:1440}}
 app.rateLimitDelayMs=${RATE_LIMIT_DELAY_MS:${env.RATE_LIMIT_DELAY_MS:200}}
-app.ratelimit.initialBucketSize=${RATE_LIMIT_INITIAL_BUCKET_SIZE:200}
-app.ratelimit.refillPerMinute=${RATE_LIMIT_REFILL_PER_MINUTE:100}
+app.ratelimit.initialBucketSize=${RATE_LIMIT_INITIAL_BUCKET_SIZE:500}
+app.ratelimit.refillPerMinute=${RATE_LIMIT_REFILL_PER_MINUTE:250}
 
 # 0 0 0 * * * = midnight every day
 # 0 0 * * * * = top of every hour


### PR DESCRIPTION
This hot fix increases the ip rate limit bucket size.

The values of 200 and 100 were not enough for normal operation; we were getting IP rate limited when doing normal things on localhost.